### PR TITLE
Remove errant second `buildConfig` DSL block

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,7 @@ If you add in your `build.gradle.kts`:
 ```kotlin
 buildConfig {
     sourceSets.getByName("test") {
-        buildConfig {
-            buildConfigField("String", "TEST_CONSTANT", "\"aTestValue\"")
-        }
+        buildConfigField("String", "TEST_CONSTANT", "\"aTestValue\"")
     }
 }
 ```


### PR DESCRIPTION
Despite being nested inside a source set block, this re-use of the `buildConfig` DSL block will undo the scoping.