### PR TITLE
Remove incorrect parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Will generate `BuildConfig.kt`:
 const val APP_NAME: String = "example-kts"
 
 const val APP_VERSION: String = "0.0.1"
-}
 ```
 ## Values greater than 100 characters
 In some cases, such as embedded public certs, your build config values may exceed 100 characters in length and will become subject to line wrapping by the [Kotlin Poet](https://square.github.io/kotlinpoet/#spaces-wrap-by-default) output. If you need to workaround this behavior, you can explicitly control or prevent line wrapping by replacing spaces with a `·` character.


### PR DESCRIPTION
Removed incorrect parentheses at the end of the `BuildConfig.kt` code in the `Generate top-level constants` section.