### PR TITLE
Mark the generated BuildConfig directory as a main source set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ plugins {
 // Make IDE recognize the generated BuildConfig file
 kotlin.sourceSets {
     main {
-        kotlin.srcDirs(
-            file("$buildDir/generated/source/buildConfig/main"),
-        )
+        kotlin.srcDirs(tasks.named<BuildConfigTask>("generateBuildConfig").get().outputDir)
     }
 }
 
@@ -72,7 +70,7 @@ plugins {
 // Make IDE recognize the generated BuildConfig file
 kotlin {
     sourceSets {
-        main.kotlin.srcDirs += "$buildDir/generated/source/buildConfig/main"
+        main.kotlin.srcDirs += tasks.named("generateBuildConfig").get().outputDir
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ plugins {
     id("com.github.gmazzo.buildconfig") version <current version>
 }
 
+// Make IDE recognize the generated BuildConfig file
+kotlin.sourceSets {
+    main {
+        kotlin.srcDirs(
+            file("$buildDir/generated/source/buildConfig"),
+        )
+    }
+}
+
 buildConfig {
     buildConfigField("String", "APP_NAME", "\"${project.name}\"")
     buildConfigField("String", "APP_VERSION", provider { "\"${project.version}\"" })
@@ -58,6 +67,13 @@ On your `build.gradle` add:
 plugins {
     id 'java'
     id 'com.github.gmazzo.buildconfig' version <current version>
+}
+
+// Make IDE recognize the generated BuildConfig file
+kotlin {
+    sourceSets {
+        main.kotlin.srcDirs += "$buildDir/generated/source/buildConfig"
+    }
 }
 
 buildConfig {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ plugins {
 kotlin.sourceSets {
     main {
         kotlin.srcDirs(
-            file("$buildDir/generated/source/buildConfig"),
+            file("$buildDir/generated/source/buildConfig/main"),
         )
     }
 }
@@ -72,7 +72,7 @@ plugins {
 // Make IDE recognize the generated BuildConfig file
 kotlin {
     sourceSets {
-        main.kotlin.srcDirs += "$buildDir/generated/source/buildConfig"
+        main.kotlin.srcDirs += "$buildDir/generated/source/buildConfig/main"
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/gmazzo/gradle-buildconfig-plugin/issues/36