### PR TITLE
Fixed generator cache inputs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1g
+org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
 #org.gradle.configuration-cache=true FIXME `git-versioning` and `kotlin-multiplatform` are not compatible

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTask.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTask.kt
@@ -6,7 +6,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class BuildConfigTask : DefaultTask() {
@@ -14,13 +17,8 @@ abstract class BuildConfigTask : DefaultTask() {
     @get:Nested
     abstract val specs: SetProperty<BuildConfigClassSpec>
 
-    @get:Internal
+    @get:Nested
     abstract val generator: Property<BuildConfigGenerator>
-
-    @get:Input
-    @Suppress("unused")
-    internal val generatorName
-        get() = generator.javaClass
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/generators/BuildConfigJavaGenerator.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/generators/BuildConfigJavaGenerator.kt
@@ -3,10 +3,11 @@ package com.github.gmazzo.gradle.plugins.generators
 import com.squareup.javapoet.*
 import org.apache.commons.lang3.ClassUtils
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Input
 import javax.lang.model.element.Modifier
 
 data class BuildConfigJavaGenerator(
-    var defaultVisibility: Boolean = false
+    @get:Input var defaultVisibility: Boolean = false
 ) : BuildConfigGenerator {
 
     private val logger = Logging.getLogger(javaClass)

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/generators/BuildConfigKotlinGenerator.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/generators/BuildConfigKotlinGenerator.kt
@@ -4,10 +4,11 @@ import com.github.gmazzo.gradle.plugins.BuildConfigField
 import com.squareup.kotlinpoet.*
 import org.apache.commons.lang3.ClassUtils
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Input
 
 data class BuildConfigKotlinGenerator(
-    var topLevelConstants: Boolean = false,
-    var internalVisibility: Boolean = true
+    @get:Input var topLevelConstants: Boolean = false,
+    @get:Input var internalVisibility: Boolean = true
 ) : BuildConfigGenerator {
 
     private val constTypes = setOf(String::class.asClassName(), BOOLEAN, BYTE, SHORT, INT, LONG, CHAR, FLOAT, DOUBLE)

--- a/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigPluginTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigPluginTest.kt
@@ -188,7 +188,7 @@ class BuildConfigPluginTest {
 
         val projectDir =
             File(
-                "test-project/" +
+                "${BuildConfigPluginTest::class.simpleName}/" +
                         "gradle-$gradleVersion/" +
                         "kotlin-${kotlinVersion ?: "none"}/" +
                         (if (withPackage) "withPackage/" else "withoutPackage/") +

--- a/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTaskCacheabilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTaskCacheabilityTest.kt
@@ -1,0 +1,89 @@
+package com.github.gmazzo.gradle.plugins
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import java.io.File
+import kotlin.test.assertEquals
+
+@Execution(ExecutionMode.SAME_THREAD)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BuildConfigTaskCacheabilityTest {
+
+    private val projectDir = File("${BuildConfigTaskCacheabilityTest::class.simpleName}")
+
+    private val buildScript = File(projectDir, "build.gradle.kts")
+
+    private val runner = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments("clean", "jar")
+        .forwardOutput()
+
+    @BeforeAll
+    fun setup() {
+        projectDir.deleteRecursively()
+        projectDir.mkdirs()
+
+        File(projectDir, "gradle.properties").writeText(
+            """
+            org.gradle.caching=true
+            org.gradle.configuration-cache=true
+        """.trimIndent()
+        )
+
+        File(projectDir, "settings.gradle.kts").writeText("""
+            dependencyResolutionManagement {
+                repositories {
+                    mavenCentral()
+                }
+            }
+        """.trimIndent())
+
+        buildScript.writeText(
+            """
+            plugins {
+                kotlin("jvm") version embeddedKotlinVersion
+                id("com.github.gmazzo.buildconfig")
+            }
+            
+            buildConfig {
+                buildConfigField("String", "SOME_FIELD", "\"aValue\"")
+            }
+            
+        """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `using java, cacheability should succeeded`() {
+        buildScript.appendText("buildConfig.useJavaOutput()\n")
+
+        val firstRun = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfig")?.outcome)
+
+        val secondRun = runner.build()
+        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfig")?.outcome)
+    }
+
+    @Test
+    fun `using kotlin, cacheability should succeeded`() {
+        buildScript.appendText("buildConfig.useKotlinOutput()\n")
+
+        val firstRun = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfig")?.outcome)
+
+        val secondRun = runner.build()
+        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfig")?.outcome)
+
+        buildScript.appendText("buildConfig.useKotlinOutput { topLevelConstants = true }\n")
+
+        val thirdRun = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, thirdRun.task(":generateBuildConfig")?.outcome)
+    }
+
+}


### PR DESCRIPTION
Replaces `generator` input strategy to `@Nested` to pick configuration changes on each generator instance (like changing `topLevelConstants` from `false` to `true`)

Before this change, configuration changes using the same generator will incorrectly be computed as a cache hit giving `UP-TO-DATE` and `FROM-CACHE` task outputs when constant classes should be regenerated.