### PR TITLE
Added `position` to `BuildConfigField` to keep the insertion order

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -29,7 +29,9 @@ dependencies {
     implementation(libs.apache.commons.lang)
 
     testImplementation(gradleTestKit())
+    testImplementation(gradleKotlinDsl())
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.mockk)
     testImplementation("org.junit.jupiter:junit-jupiter-params")
 }
 

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigField.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigField.kt
@@ -18,4 +18,7 @@ interface BuildConfigField : Named {
     @get:Input
     val optional: Property<Boolean>
 
+    @get:Input
+    val position: Property<Int>
+
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTask.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTask.kt
@@ -24,7 +24,7 @@ abstract class BuildConfigTask : DefaultTask() {
     abstract val outputDir: DirectoryProperty
 
     @TaskAction
-    protected fun generateBuildConfigFile() = outputDir.get().asFile.let { dir ->
+    fun generateBuildConfigFile() = outputDir.get().asFile.let { dir ->
         dir.deleteRecursively()
         dir.mkdirs()
 
@@ -45,7 +45,12 @@ abstract class BuildConfigTask : DefaultTask() {
                 BuildConfigGeneratorSpec(
                     className = className,
                     packageName = packageName,
-                    fields = it.buildConfigFields,
+                    fields = it.buildConfigFields.sortedWith { a, b ->
+                        when (val cmp = a.position.get().compareTo(b.position.get())) {
+                            0 -> a.name.compareTo(b.name)
+                            else -> cmp
+                        }
+                    },
                     outputDir = dir
                 )
             )

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/internal/DefaultBuildConfigClassSpec.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/internal/DefaultBuildConfigClassSpec.kt
@@ -16,12 +16,14 @@ internal abstract class DefaultBuildConfigClassSpec @Inject constructor(
         type: String,
         name: String,
         action: (BuildConfigField) -> Unit,
-    ) : NamedDomainObjectProvider<BuildConfigField> =
+    ): NamedDomainObjectProvider<BuildConfigField> = buildConfigFields.size.let { position ->
         buildConfigFields.register(name) {
             it.type.value(type.removeSuffix("?")).disallowChanges()
             it.optional.value(type.endsWith("?")).disallowChanges()
+            it.position.convention(position)
             action(it)
         }
+    }
 
     override fun buildConfigField(type: String, name: String, value: String) =
         buildConfigField(type, name) { it.value.value(value).disallowChanges() }

--- a/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTaskTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigTaskTest.kt
@@ -1,0 +1,55 @@
+package com.github.gmazzo.gradle.plugins
+
+import com.github.gmazzo.gradle.plugins.generators.BuildConfigGenerator
+import com.github.gmazzo.gradle.plugins.generators.BuildConfigGeneratorSpec
+import com.github.gmazzo.gradle.plugins.internal.DefaultBuildConfigClassSpec
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+class BuildConfigTaskTest {
+
+    private val project = ProjectBuilder.builder().build()
+
+    private val spec: BuildConfigClassSpec = project.objects.newInstance<DefaultBuildConfigClassSpec>("spec").apply {
+        className.set("aClassName")
+        packageName.set("aPackage")
+    }
+
+    private val outDir = project.layout.buildDirectory.dir("outDir")
+
+    private val generator: BuildConfigGenerator = mockk(relaxUnitFun = true)
+
+    private val task = project.tasks.create<BuildConfigTask>("testedTask") {
+        generator.set(this@BuildConfigTaskTest.generator)
+        outputDir.set(outDir)
+        specs.add(spec)
+    }
+
+    @Test
+    fun `order of fields must be honored when propagated to the generator`() {
+        val fields = sequenceOf(
+            spec.buildConfigField("Int", "FIRST", "1"),
+            spec.buildConfigField("Int", "SECOND", "2"),
+            spec.buildConfigField("Int", "THIRD", "3"),
+            spec.buildConfigField("Int", "LAST", "9"),
+        ).map { it.get() }.toList()
+
+        task.generateBuildConfigFile()
+
+        verify {
+            generator.execute(
+                BuildConfigGeneratorSpec(
+                    className = "aClassName",
+                    packageName = "aPackage",
+                    fields = fields,
+                    outputDir = outDir.get().asFile.absoluteFile,
+                )
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #52 allowing to keep the insertion order, by introducing a `position` field to `BuildConfigField`  which defaults to the collection size.