### PR TITLE
Added `BuildConfigDsl` marker to prevent accidental scope issues

### DIFF
--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigClassSpec.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigClassSpec.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
+@BuildConfigDsl
 interface BuildConfigClassSpec : Named {
 
     @Input

--- a/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigDsl.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/gradle/plugins/BuildConfigDsl.kt
@@ -1,0 +1,4 @@
+package com.github.gmazzo.gradle.plugins
+
+@DslMarker
+annotation class BuildConfigDsl


### PR DESCRIPTION
After major `v4` there is a breaking change not easily to detect because members of `BuildConfigSourceSet` can still be accessed from inside `BuildConfigClassSpec`.

This change will forgive that facilitating the migration:
![image](https://github.com/gmazzo/gradle-buildconfig-plugin/assets/513566/be0bcdec-e877-43a8-aed8-6d7bacd31617)