### PR TITLE
Fix plugin badge showing an outdated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub](https://img.shields.io/github/license/gmazzo/gradle-buildconfig-plugin)
-[![Plugins Site](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/gmazzo/buildconfig/plugin/maven-metadata.xml.svg?label=gradle-plugins)](https://plugins.gradle.org/plugin/com.github.gmazzo.buildconfig)
+![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.github.gmazzo.buildconfig)
 ![Build Status](https://github.com/gmazzo/gradle-buildconfig-plugin/actions/workflows/build.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub](https://img.shields.io/github/license/gmazzo/gradle-buildconfig-plugin)
-[![Plugins Site](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/gmazzo/gradle-buildconfig-plugin/maven-metadata.xml.svg?label=gradle-plugins)](https://plugins.gradle.org/plugin/com.github.gmazzo.buildconfig)
+[![Plugins Site](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/gmazzo/buildconfig/plugin/maven-metadata.xml.svg?label=gradle-plugins)](https://plugins.gradle.org/plugin/com.github.gmazzo.buildconfig)
 ![Build Status](https://github.com/gmazzo/gradle-buildconfig-plugin/actions/workflows/build.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin)
 


### PR DESCRIPTION
Also would you mind editing [4.0.0](https://github.com/gmazzo/gradle-buildconfig-plugin/releases/tag/v4.0.0) and adding this list item:
 * Dependency coordinates changed from `com.github.gmazzo:gradle-buildconfig-plugin` to `com.github.gmazzo.buildconfig:plugin`; Gradle Plugin ID and Marker stayed the same.
