### PR TITLE
Bump JDK version to 11

### DIFF
--- a/demo-project/kts-android/build.gradle.kts
+++ b/demo-project/kts-android/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.github.gmazzo.buildconfig")
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
 
 android {
     namespace = "com.github.gmazzo.buildconfig.demos.android"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+java = "11"
 kotlin = "1.9.20"
 
 [libraries]

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,7 +12,7 @@ version = providers
     .exec { commandLine("git", "describe", "--tags", "--always") }
     .standardOutput.asText.get().trim().removePrefix("v")
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
 
 dependencies {
     fun DependencyHandler.plugin(dependency: Provider<PluginDependency>) =


### PR DESCRIPTION
Some dependencies now ships for JDK>11 only, Android SDK requires 17. It's time to drop JDK 8