### PR TITLE
Fix configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     base
+    `maven-publish`
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
@@ -26,12 +27,12 @@ tasks.check {
     dependsOn(jacocoTestReport.reportTask, pluginBuild.task(":$name"))
 }
 
-tasks.register(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME) {
+tasks.publish {
     dependsOn(pluginBuild.task(":$name"))
     finalizedBy(tasks.reportPublications)
 }
 
-tasks.register(MavenPublishPlugin.PUBLISH_LOCAL_LIFECYCLE_TASK_NAME) {
+tasks.publishToMavenLocal {
     dependsOn(pluginBuild.task(":$name"))
     finalizedBy(tasks.reportPublications)
 }

--- a/demo-project/groovy/build.gradle
+++ b/demo-project/groovy/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'groovy'
+    id 'java'
     id 'com.github.gmazzo.buildconfig'
     id 'java-test-fixtures'
 }
@@ -45,8 +45,8 @@ buildConfig {
     buildConfigField(byte[], "BYTE_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
     buildConfigField(Byte[], "BYTE_ARRAY", [1, 2, 3])
     buildConfigField(Byte[], "BYTE_ARRAY_PROVIDER", provider { [1, 2, 3] })
-    buildConfigField(Byte[], "BYTE_ARRAY_NULLABLE", [1, null, 3])
-    buildConfigField(Byte[], "BYTE_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Byte?[]', "BYTE_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Byte?[]', "BYTE_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
     buildConfigField('List<Byte>', "BYTE_LIST", [1, null, 3])
     buildConfigField('List<Byte>', "BYTE_LIST_PROVIDER", provider { [1, null, 3] })
     buildConfigField('Set<Byte>', "BYTE_SET", [1, null, 3])
@@ -60,8 +60,8 @@ buildConfig {
     buildConfigField(short[], "SHORT_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
     buildConfigField(Short[], "SHORT_ARRAY", [1, 2, 3])
     buildConfigField(Short[], "SHORT_ARRAY_PROVIDER", provider { [1, 2, 3] })
-    buildConfigField(Short[], "SHORT_ARRAY_NULLABLE", [1, null, 3])
-    buildConfigField(Short[], "SHORT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Short?[]', "SHORT_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Short?[]', "SHORT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
     buildConfigField('List<Short>', "SHORT_LIST", [1, null, 3])
     buildConfigField('List<Short>', "SHORT_LIST_PROVIDER", provider { [1, null, 3] })
     buildConfigField('Set<Short>', "SHORT_SET", [1, null, 3])
@@ -75,8 +75,8 @@ buildConfig {
     buildConfigField(char[], "CHAR_NATIVE_ARRAY_PROVIDER", provider { ['a' as char, 'b' as char, 'c' as char] })
     buildConfigField(Character[], "CHAR_ARRAY", ['a' as char, 'b' as char, 'c' as char])
     buildConfigField(Character[], "CHAR_ARRAY_PROVIDER", provider { ['a' as char, 'b' as char, 'c' as char] })
-    buildConfigField(Character[], "CHAR_ARRAY_NULLABLE", ['a' as char, null, 'c' as char])
-    buildConfigField(Character[], "CHAR_ARRAY_NULLABLE_PROVIDER", provider { ['a' as char, null, 'c' as char] })
+    buildConfigField('Character?[]', "CHAR_ARRAY_NULLABLE", ['a' as char, null, 'c' as char])
+    buildConfigField('Character?[]', "CHAR_ARRAY_NULLABLE_PROVIDER", provider { ['a' as char, null, 'c' as char] })
     buildConfigField('List<Character>', "CHAR_LIST", ['a' as char, null, 'c' as char])
     buildConfigField('List<Character>', "CHAR_LIST_PROVIDER", provider { ['a' as char, null, 'c' as char] })
     buildConfigField('Set<Character>', "CHAR_SET", ['a' as char, null, 'c' as char])
@@ -90,8 +90,8 @@ buildConfig {
     buildConfigField(int[], "INT_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
     buildConfigField(Integer[], "INT_ARRAY", [1, 2, 3])
     buildConfigField(Integer[], "INT_ARRAY_PROVIDER", provider { [1, 2, 3] })
-    buildConfigField(Integer[], "INT_ARRAY_NULLABLE", [1, null, 3])
-    buildConfigField(Integer[], "INT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Integer?[]', "INT_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Integer?[]', "INT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
     buildConfigField('List<Integer>', "INT_LIST", [1, null, 3])
     buildConfigField('List<Integer>', "INT_LIST_PROVIDER", provider { [1, null, 3] })
     buildConfigField('Set<Integer>', "INT_SET", [1, null, 3])
@@ -105,8 +105,8 @@ buildConfig {
     buildConfigField(long[], "LONG_NATIVE_ARRAY_PROVIDER", provider { [1L, 2L, 3L] })
     buildConfigField(Long[], "LONG_ARRAY", [1L, 2L, 3L])
     buildConfigField(Long[], "LONG_ARRAY_PROVIDER", provider { [1L, 2L, 3L] })
-    buildConfigField(Long[], "LONG_ARRAY_NULLABLE", [1L, null, 3L])
-    buildConfigField(Long[], "LONG_ARRAY_NULLABLE_PROVIDER", provider { [1L, null, 3L] })
+    buildConfigField('Long?[]', "LONG_ARRAY_NULLABLE", [1L, null, 3L])
+    buildConfigField('Long?[]', "LONG_ARRAY_NULLABLE_PROVIDER", provider { [1L, null, 3L] })
     buildConfigField('List<Long>', "LONG_LIST", [1L, null, 3L])
     buildConfigField('List<Long>', "LONG_LIST_PROVIDER", provider { [1L, null, 3L] })
     buildConfigField('Set<Long>', "LONG_SET", [1L, null, 3L])
@@ -120,8 +120,8 @@ buildConfig {
     buildConfigField(float[], "FLOAT_NATIVE_ARRAY_PROVIDER", provider { [1f, 2f, 3f] })
     buildConfigField(Float[], "FLOAT_ARRAY", [1f, 2f, 3f])
     buildConfigField(Float[], "FLOAT_ARRAY_PROVIDER", provider { [1f, 2f, 3f] })
-    buildConfigField(Float[], "FLOAT_ARRAY_NULLABLE", [1f, null, 3f])
-    buildConfigField(Float[], "FLOAT_ARRAY_NULLABLE_PROVIDER", provider { [1f, null, 3f] })
+    buildConfigField('Float?[]', "FLOAT_ARRAY_NULLABLE", [1f, null, 3f])
+    buildConfigField('Float?[]', "FLOAT_ARRAY_NULLABLE_PROVIDER", provider { [1f, null, 3f] })
     buildConfigField('List<Float>', "FLOAT_LIST", [1f, null, 3f])
     buildConfigField('List<Float>', "FLOAT_LIST_PROVIDER", provider { [1f, null, 3f] })
     buildConfigField('Set<Float>', "FLOAT_SET", [1f, null, 3f])
@@ -135,8 +135,8 @@ buildConfig {
     buildConfigField(double[], "DOUBLE_NATIVE_ARRAY_PROVIDER", provider { [1.0, 2.0, 3.0] })
     buildConfigField(Double[], "DOUBLE_ARRAY", [1.0, 2.0, 3.0])
     buildConfigField(Double[], "DOUBLE_ARRAY_PROVIDER", provider { [1.0, 2.0, 3.0] })
-    buildConfigField(Double[], "DOUBLE_ARRAY_NULLABLE", [1.0, null, 3.0])
-    buildConfigField(Double[], "DOUBLE_ARRAY_NULLABLE_PROVIDER", provider { [1.0, null, 3.0] })
+    buildConfigField('Double?[]', "DOUBLE_ARRAY_NULLABLE", [1.0, null, 3.0])
+    buildConfigField('Double?[]', "DOUBLE_ARRAY_NULLABLE_PROVIDER", provider { [1.0, null, 3.0] })
     buildConfigField('List<Double>', "DOUBLE_LIST", [1.0, null, 3.0])
     buildConfigField('List<Double>', "DOUBLE_LIST_PROVIDER", provider { [1.0, null, 3.0] })
     buildConfigField('Set<Double>', "DOUBLE_SET", [1.0, null, 3.0])
@@ -150,8 +150,8 @@ buildConfig {
     buildConfigField(boolean[], "BOOLEAN_NATIVE_ARRAY_PROVIDER", provider { [true, false, false] })
     buildConfigField(Boolean[], "BOOLEAN_ARRAY", [true, false, false])
     buildConfigField(Boolean[], "BOOLEAN_ARRAY_PROVIDER", provider { [true, false, false] })
-    buildConfigField(Boolean[], "BOOLEAN_ARRAY_NULLABLE", [true, null, false])
-    buildConfigField(Boolean[], "BOOLEAN_ARRAY_NULLABLE_PROVIDER", provider { [true, null, false] })
+    buildConfigField('Boolean?[]', "BOOLEAN_ARRAY_NULLABLE", [true, null, false])
+    buildConfigField('Boolean?[]', "BOOLEAN_ARRAY_NULLABLE_PROVIDER", provider { [true, null, false] })
     buildConfigField('List<Boolean>', "BOOLEAN_LIST", [true, null, false])
     buildConfigField('List<Boolean>', "BOOLEAN_LIST_PROVIDER", provider { [true, null, false] })
     buildConfigField('Set<Boolean>', "BOOLEAN_SET", [true, null, false])
@@ -195,19 +195,12 @@ sourceSets {
 /**
  *  A task that iterates over your classpath resources and generate constants for them
  */
-def buildResources = buildConfig.forClass("BuildResources") {
+buildConfig.forClass("BuildResources") {
     buildConfigField('String', 'A_CONSTANT', '"aConstant"')
-}
-def generateResourcesConstants = tasks.register("generateResourcesConstants") {
-    doFirst {
-        sourceSets.main.resources.asFileTree.visit { file ->
-            def name = file.path.toUpperCase().replaceAll("\\W", "_")
 
-            buildResources.buildConfigField('java.io.File', name, "new File(\"$file.path\")")
-        }
+    sourceSets.main.resources.asFileTree.visit {
+        def name = it.path.toUpperCase().replaceAll("\\W", "_")
+
+        buildConfigField('java.io.File', name, "new File(\"${it.path}\")")
     }
-}
-
-tasks.generateBuildConfig {
-    dependsOn(generateResourcesConstants)
 }

--- a/demo-project/groovy/src/testFixtures/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigBaseTest.java
+++ b/demo-project/groovy/src/testFixtures/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigBaseTest.java
@@ -2,12 +2,9 @@ package com.github.gmazzo.buildconfig.demos.groovy;
 
 import org.junit.Test;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -46,8 +43,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(64, BuildConfig.BYTE_PROVIDER);
         assertArrayEquals(new byte[]{1, 2, 3}, BuildConfig.BYTE_NATIVE_ARRAY);
         assertArrayEquals(new byte[]{1, 2, 3}, BuildConfig.BYTE_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Byte[]{1, 2, 3}, BuildConfig.BYTE_ARRAY);
-        assertArrayEquals(new Byte[]{1, 2, 3}, BuildConfig.BYTE_ARRAY_PROVIDER);
+        assertArrayEquals(new byte[]{1, 2, 3}, BuildConfig.BYTE_ARRAY);
+        assertArrayEquals(new byte[]{1, 2, 3}, BuildConfig.BYTE_ARRAY_PROVIDER);
         assertArrayEquals(new Byte[]{1, null, 3}, BuildConfig.BYTE_ARRAY_NULLABLE);
         assertArrayEquals(new Byte[]{1, null, 3}, BuildConfig.BYTE_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList((byte) 1, null, (byte) 3), BuildConfig.BYTE_LIST);
@@ -63,8 +60,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(64, BuildConfig.SHORT_PROVIDER);
         assertArrayEquals(new short[]{1, 2, 3}, BuildConfig.SHORT_NATIVE_ARRAY);
         assertArrayEquals(new short[]{1, 2, 3}, BuildConfig.SHORT_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Short[]{1, 2, 3}, BuildConfig.SHORT_ARRAY);
-        assertArrayEquals(new Short[]{1, 2, 3}, BuildConfig.SHORT_ARRAY_PROVIDER);
+        assertArrayEquals(new short[]{1, 2, 3}, BuildConfig.SHORT_ARRAY);
+        assertArrayEquals(new short[]{1, 2, 3}, BuildConfig.SHORT_ARRAY_PROVIDER);
         assertArrayEquals(new Short[]{1, null, 3}, BuildConfig.SHORT_ARRAY_NULLABLE);
         assertArrayEquals(new Short[]{1, null, 3}, BuildConfig.SHORT_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList((short) 1, null, (short) 3), BuildConfig.SHORT_LIST);
@@ -80,8 +77,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals('a', BuildConfig.CHAR_PROVIDER);
         assertArrayEquals(new char[]{'a', 'b', 'c'}, BuildConfig.CHAR_NATIVE_ARRAY);
         assertArrayEquals(new char[]{'a', 'b', 'c'}, BuildConfig.CHAR_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Character[]{'a', 'b', 'c'}, BuildConfig.CHAR_ARRAY);
-        assertArrayEquals(new Character[]{'a', 'b', 'c'}, BuildConfig.CHAR_ARRAY_PROVIDER);
+        assertArrayEquals(new char[]{'a', 'b', 'c'}, BuildConfig.CHAR_ARRAY);
+        assertArrayEquals(new char[]{'a', 'b', 'c'}, BuildConfig.CHAR_ARRAY_PROVIDER);
         assertArrayEquals(new Character[]{'a', null, 'c'}, BuildConfig.CHAR_ARRAY_NULLABLE);
         assertArrayEquals(new Character[]{'a', null, 'c'}, BuildConfig.CHAR_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList('a', null, 'c'), BuildConfig.CHAR_LIST);
@@ -97,8 +94,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(1, BuildConfig.INT_PROVIDER);
         assertArrayEquals(new int[]{1, 2, 3}, BuildConfig.INT_NATIVE_ARRAY);
         assertArrayEquals(new int[]{1, 2, 3}, BuildConfig.INT_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Integer[]{1, 2, 3}, BuildConfig.INT_ARRAY);
-        assertArrayEquals(new Integer[]{1, 2, 3}, BuildConfig.INT_ARRAY_PROVIDER);
+        assertArrayEquals(new int[]{1, 2, 3}, BuildConfig.INT_ARRAY);
+        assertArrayEquals(new int[]{1, 2, 3}, BuildConfig.INT_ARRAY_PROVIDER);
         assertArrayEquals(new Integer[]{1, null, 3}, BuildConfig.INT_ARRAY_NULLABLE);
         assertArrayEquals(new Integer[]{1, null, 3}, BuildConfig.INT_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList(1, null, 3), BuildConfig.INT_LIST);
@@ -114,8 +111,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(1, BuildConfig.LONG_PROVIDER);
         assertArrayEquals(new long[]{1L, 2L, 3L}, BuildConfig.LONG_NATIVE_ARRAY);
         assertArrayEquals(new long[]{1L, 2L, 3L}, BuildConfig.LONG_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Long[]{1L, 2L, 3L}, BuildConfig.LONG_ARRAY);
-        assertArrayEquals(new Long[]{1L, 2L, 3L}, BuildConfig.LONG_ARRAY_PROVIDER);
+        assertArrayEquals(new long[]{1L, 2L, 3L}, BuildConfig.LONG_ARRAY);
+        assertArrayEquals(new long[]{1L, 2L, 3L}, BuildConfig.LONG_ARRAY_PROVIDER);
         assertArrayEquals(new Long[]{1L, null, 3L}, BuildConfig.LONG_ARRAY_NULLABLE);
         assertArrayEquals(new Long[]{1L, null, 3L}, BuildConfig.LONG_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList(1L, null, 3L), BuildConfig.LONG_LIST);
@@ -131,8 +128,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(1, BuildConfig.FLOAT_PROVIDER, 0);
         assertArrayEquals(new float[]{1f, 2f, 3f}, BuildConfig.FLOAT_NATIVE_ARRAY, 0);
         assertArrayEquals(new float[]{1f, 2f, 3f}, BuildConfig.FLOAT_NATIVE_ARRAY_PROVIDER, 0);
-        assertArrayEquals(new Float[]{1f, 2f, 3f}, BuildConfig.FLOAT_ARRAY);
-        assertArrayEquals(new Float[]{1f, 2f, 3f}, BuildConfig.FLOAT_ARRAY_PROVIDER);
+        assertArrayEquals(new float[]{1f, 2f, 3f}, BuildConfig.FLOAT_ARRAY, 0);
+        assertArrayEquals(new float[]{1f, 2f, 3f}, BuildConfig.FLOAT_ARRAY_PROVIDER, 0);
         assertArrayEquals(new Float[]{1f, null, 3f}, BuildConfig.FLOAT_ARRAY_NULLABLE);
         assertArrayEquals(new Float[]{1f, null, 3f}, BuildConfig.FLOAT_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList(1f, null, 3f), BuildConfig.FLOAT_LIST);
@@ -148,8 +145,8 @@ public abstract class BuildConfigBaseTest {
         assertEquals(1, BuildConfig.DOUBLE_PROVIDER, 0);
         assertArrayEquals(new double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_NATIVE_ARRAY, 0);
         assertArrayEquals(new double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_NATIVE_ARRAY_PROVIDER, 0);
-        assertArrayEquals(new Double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_ARRAY);
-        assertArrayEquals(new Double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_ARRAY_PROVIDER);
+        assertArrayEquals(new double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_ARRAY, 0);
+        assertArrayEquals(new double[]{1.0, 2.0, 3.0}, BuildConfig.DOUBLE_ARRAY_PROVIDER, 0);
         assertArrayEquals(new Double[]{1.0, null, 3.0}, BuildConfig.DOUBLE_ARRAY_NULLABLE);
         assertArrayEquals(new Double[]{1.0, null, 3.0}, BuildConfig.DOUBLE_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList(1.0, null, 3.0), BuildConfig.DOUBLE_LIST);
@@ -165,8 +162,8 @@ public abstract class BuildConfigBaseTest {
         assertTrue(BuildConfig.BOOLEAN_PROVIDER);
         assertArrayEquals(new boolean[]{true, false, false}, BuildConfig.BOOLEAN_NATIVE_ARRAY);
         assertArrayEquals(new boolean[]{true, false, false}, BuildConfig.BOOLEAN_NATIVE_ARRAY_PROVIDER);
-        assertArrayEquals(new Boolean[]{true, false, false}, BuildConfig.BOOLEAN_ARRAY);
-        assertArrayEquals(new Boolean[]{true, false, false}, BuildConfig.BOOLEAN_ARRAY_PROVIDER);
+        assertArrayEquals(new boolean[]{true, false, false}, BuildConfig.BOOLEAN_ARRAY);
+        assertArrayEquals(new boolean[]{true, false, false}, BuildConfig.BOOLEAN_ARRAY_PROVIDER);
         assertArrayEquals(new Boolean[]{true, null, false}, BuildConfig.BOOLEAN_ARRAY_NULLABLE);
         assertArrayEquals(new Boolean[]{true, null, false}, BuildConfig.BOOLEAN_ARRAY_NULLABLE_PROVIDER);
         assertEquals(Arrays.asList(true, null, false), BuildConfig.BOOLEAN_LIST);

--- a/demo-project/kts-multiplatform/build.gradle.kts
+++ b/demo-project/kts-multiplatform/build.gradle.kts
@@ -33,3 +33,7 @@ buildConfig {
 tasks.register("test") {
     dependsOn("allTests")
 }
+
+tasks.named("compileTestDevelopmentExecutableKotlinJs") {
+    notCompatibleWithConfigurationCache("uses Task.project")
+}

--- a/demo-project/kts/build.gradle.kts
+++ b/demo-project/kts/build.gradle.kts
@@ -203,23 +203,17 @@ val versionsSS = buildConfig.sourceSets.register("Versions") {
     buildConfigField("myDependencyVersion", "1.0.1")
 }
 
-val buildResources = buildConfig.forClass("BuildResources") {
+/**
+ *  A task that iterates over your classpath resources and generate constants for them
+ */
+buildConfig.forClass("BuildResources") {
     buildConfigField("A_CONSTANT", "aConstant")
-}
-val generateResourcesConstants by tasks.registering {
-    doFirst {
-        sourceSets["main"].resources.asFileTree.visit {
-            val name = path.uppercase().replace("\\W".toRegex(), "_")
 
-            with(buildResources) {
-                buildConfigField("java.io.File", name, "File(\"$path\")")
-            }
-        }
+    sourceSets["main"].resources.asFileTree.visit {
+        val name = path.uppercase().replace("\\W".toRegex(), "_")
+
+        buildConfigField("java.io.File", name, "File(\"$path\")")
     }
-}
-
-tasks.generateBuildConfig {
-    dependsOn(generateResourcesConstants)
 }
 
 // example of a custom generator that builds into XML

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
-org.gradle.configuration-cache=true FIXME `kotlin-multiplatform` are not compatible
+org.gradle.configuration-cache=true

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -65,3 +65,7 @@ tasks.check {
 tasks.publish {
     dependsOn(tasks.publishPlugins)
 }
+
+tasks.generateJacocoTestKitProperties {
+    notCompatibleWithConfigurationCache("uses Task.extensions")
+}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.internal.catalog.ExternalModuleDependencyFactory
-
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.gradle.pluginPublish)
@@ -24,9 +22,6 @@ kotlin {
 dependencies {
     fun DependencyHandler.plugin(dependency: Provider<PluginDependency>) =
         dependency.get().run { create("$pluginId:$pluginId.gradle.plugin:$version") }
-
-    fun DependencyHandler.plugin(dependency: ExternalModuleDependencyFactory.PluginNotationSupplier) =
-        plugin(dependency.asProvider())
 
     compileOnly(gradleKotlinDsl())
     compileOnly(plugin(libs.plugins.kotlin.jvm))

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigClassSpec.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigClassSpec.kt
@@ -59,7 +59,7 @@ interface BuildConfigClassSpec : Named {
         type: Class<out Type>,
         name: String,
         value: Type?,
-    ) = addField(typeOf(type), name, valueOf(castToType(value, type) as Serializable))
+    ) = addField(nameOf(type), name, valueOf(castToType(value, type) as Serializable))
 
     fun buildConfigField(
         type: String,
@@ -71,6 +71,6 @@ interface BuildConfigClassSpec : Named {
         type: Class<out Type>,
         name: String,
         value: Provider<out Type>,
-    ) = addField(typeOf(type), name, value.map { valueOf(castToType(it, type) as Serializable) })
+    ) = addField(nameOf(type), name, value.map { valueOf(castToType(it, type) as Serializable) })
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
@@ -3,6 +3,7 @@ package com.github.gmazzo.buildconfig
 import org.gradle.api.Named
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 interface BuildConfigField : Named {
 
@@ -10,12 +11,13 @@ interface BuildConfigField : Named {
     override fun getName(): String
 
     @get:Input
-    val type: Property<BuildConfigType<*>>
+    val type: Property<BuildConfigType>
 
     @get:Input
     val value: Property<BuildConfigValue>
 
     @get:Input
+    @get:Optional
     val position: Property<Int>
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTask.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTask.kt
@@ -47,7 +47,7 @@ abstract class BuildConfigTask : DefaultTask() {
                     packageName = packageName,
                     documentation = it.documentation.orNull,
                     fields = it.buildConfigFields.sortedWith { a, b ->
-                        when (val cmp = a.position.get().compareTo(b.position.get())) {
+                        when (val cmp = a.position.getOrElse(0).compareTo(b.position.getOrElse(0))) {
                             0 -> a.name.compareTo(b.name)
                             else -> cmp
                         }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigType.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigType.kt
@@ -2,25 +2,26 @@ package com.github.gmazzo.buildconfig
 
 import java.io.Serializable
 
-sealed class BuildConfigType<RefType : Serializable> : Serializable {
+data class BuildConfigType @JvmOverloads constructor(
+    val className: String,
+    val typeArguments: List<BuildConfigType> = emptyList(),
+    val nullable: Boolean = false,
+    val array: Boolean = false,
+) : Serializable {
 
-    abstract val ref: RefType
-
-    abstract val typeParameters: List<BuildConfigType<*>>
-
-    data class JavaRef(
-        override val ref: Class<*>,
-        override val typeParameters: List<BuildConfigType<*>> = emptyList(),
-    ) : BuildConfigType<Class<*>>()
-
-    data class NameRef(
-        override val ref: String,
-        override val typeParameters: List<BuildConfigType<*>> = emptyList(),
-    ) : BuildConfigType<String>()
-
-    override fun toString(): String = when(typeParameters.size) {
-        0 -> ref.toString()
-        else -> "$ref<${typeParameters.joinToString(", ")}>"
+    private val text by lazy {
+        buildString {
+            append(className)
+            if (typeArguments.isNotEmpty()) {
+                append("<")
+                append(typeArguments.joinToString(", "))
+                append(">")
+            }
+            if (nullable) append("?")
+            if (array) append("[]")
+        }
     }
+
+    override fun toString(): String = text
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
@@ -2,12 +2,17 @@ package com.github.gmazzo.buildconfig
 
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.provider.Provider
+import org.jetbrains.annotations.VisibleForTesting
 import java.io.Serializable
-import kotlin.reflect.KClass
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
 
 private val regEx = "([^\\[\\]?]+?)(\\?)?(\\[])?".toRegex()
 
+@VisibleForTesting
 internal fun String.parseTypename(): Triple<String, Boolean, Boolean> {
     val match = regEx.matchEntire(this)
     checkNotNull(match) {
@@ -19,18 +24,70 @@ internal fun String.parseTypename(): Triple<String, Boolean, Boolean> {
     return Triple(type, nullable.isNotEmpty(), array.isNotEmpty())
 }
 
-internal fun typeOf(type: Class<*>) =
-    BuildConfigType.JavaRef(type)
+@Suppress("RecursivePropertyAccessor")
+private val Type.genericName: String
+    get() = when (this) {
+        Boolean::class.java, Boolean::class.javaObjectType, BooleanArray::class.java -> "Boolean"
+        Byte::class.java, Byte::class.javaObjectType, ByteArray::class.java -> "Byte"
+        Short::class.java, Short::class.javaObjectType, ShortArray::class.java -> "Short"
+        Char::class.java, Char::class.javaObjectType, CharArray::class.java -> "Char"
+        Int::class.java, Int::class.javaObjectType, IntArray::class.java -> "Int"
+        Long::class.java, Long::class.javaObjectType, LongArray::class.java -> "Long"
+        Float::class.java, Float::class.javaObjectType, FloatArray::class.java -> "Float"
+        Double::class.java, Double::class.javaObjectType, DoubleArray::class.java -> "Double"
+        String::class.java -> "String"
+        List::class.java -> "List"
+        Set::class.java -> "Set"
+        is GenericArrayType -> genericComponentType.genericName
+        is ParameterizedType -> rawType.genericName
+        is Class<*> -> if (isArray) componentType.genericName else name
+        else -> error("Unsupported type: $this")
+    }
+
+private val Type.isArray get() = when (this) {
+    is Class<*> -> isArray
+    is GenericArrayType -> true
+    else -> false
+}
+
+internal fun nameOf(type: Type): BuildConfigType = when(type) {
+    is Class<*> -> BuildConfigType(
+        className = type.genericName,
+        typeArguments = type.typeParameters.map { nameOf(it.genericDeclaration) },
+        nullable = false,
+        array = type.isArray
+    )
+    is ParameterizedType -> BuildConfigType(
+        className = type.rawType.genericName,
+        typeArguments = type.actualTypeArguments.map { nameOf(it) },
+        nullable = false,
+        array = false
+    )
+    is GenericArrayType -> BuildConfigType(
+        className = type.genericComponentType.genericName,
+        typeArguments = checkNotNull(type.genericComponentType as? ParameterizedType) {
+            "Unsupported type: $type"
+        }.actualTypeArguments.map { nameOf(it) },
+        nullable = false,
+        array = true
+    )
+    else -> error("Unsupported type: $type")
+}
 
 @PublishedApi
-internal fun nameOf(type: KType): BuildConfigType.NameRef = (type.classifier!! as KClass<*>).let { kClass ->
-    BuildConfigType.NameRef(
-        kClass.qualifiedName!! + if (type.isMarkedNullable) "?" else "",
-        if (kClass.typeParameters.isEmpty()) emptyList() else type.arguments.map { nameOf(it.type!!) }
+internal fun nameOf(type: KType): BuildConfigType {
+    val isArray = type.javaType.isArray
+    val targetType = type.takeIf { isArray }?.arguments?.singleOrNull()?.type ?: type
+
+    return BuildConfigType(
+        className = type.javaType.genericName,
+        typeArguments = targetType.arguments.map { nameOf(it.type!!) },
+        nullable = targetType.isMarkedNullable,
+        array = isArray
     )
 }
 
-internal fun nameOf(className: String): BuildConfigType.NameRef {
+internal fun nameOf(className: String): BuildConfigType {
     val iterator = className.toList().listIterator()
     val nameRef = parseName(iterator, null)
     check(!iterator.hasNext()) {
@@ -43,9 +100,9 @@ internal fun nameOf(className: String): BuildConfigType.NameRef {
 
 private fun parseName(
     iterator: ListIterator<Char>,
-    parentParameters: MutableList<BuildConfigType.NameRef>?
-): BuildConfigType.NameRef {
-    val parameters = mutableListOf<BuildConfigType.NameRef>()
+    parentParameters: MutableList<BuildConfigType>?
+): BuildConfigType {
+    val parameters = mutableListOf<BuildConfigType>()
     val name = buildString {
         while (iterator.hasNext()) {
             when (val ch = iterator.next()) {
@@ -64,7 +121,9 @@ private fun parseName(
             }
         }
     }
-    return BuildConfigType.NameRef(name, parameters)
+
+    val (typeName, nullable, array) = name.parseTypename()
+    return BuildConfigType(typeName, parameters, nullable, array)
 }
 
 @PublishedApi
@@ -76,7 +135,7 @@ internal fun valueOf(value: Serializable?) =
     BuildConfigValue.Literal(value)
 
 private fun BuildConfigClassSpec.buildConfigField(
-    type: BuildConfigType<*>,
+    type: BuildConfigType,
     name: String,
     action: (BuildConfigField) -> Unit,
 ): NamedDomainObjectProvider<BuildConfigField> = buildConfigFields.size.let { position ->
@@ -88,12 +147,12 @@ private fun BuildConfigClassSpec.buildConfigField(
 }
 
 @PublishedApi
-internal fun BuildConfigClassSpec.addField(type: BuildConfigType<*>, name: String, value: BuildConfigValue) =
+internal fun BuildConfigClassSpec.addField(type: BuildConfigType, name: String, value: BuildConfigValue) =
     buildConfigField(type, name) { it.value.value(value).disallowChanges() }
 
 @PublishedApi
 internal fun BuildConfigClassSpec.addField(
-    type: BuildConfigType<*>,
+    type: BuildConfigType,
     name: String,
     value: Provider<BuildConfigValue>
 ) =

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
@@ -2,11 +2,10 @@ package com.github.gmazzo.buildconfig.internal
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
 import com.github.gmazzo.buildconfig.addField
-import com.github.gmazzo.buildconfig.typeOf
+import com.github.gmazzo.buildconfig.nameOf
 import com.github.gmazzo.buildconfig.valueOf
 import groovy.lang.GroovyObjectSupport
 import java.io.Serializable
-import java.lang.reflect.Type
 
 /**
  * Workaround for Groovy's `null` value issue when calling overloaded methods limitation:
@@ -24,6 +23,6 @@ internal abstract class GroovyNullValueWorkaround : BuildConfigClassSpec, Groovy
         name: String,
         value: Any?, // this should be `Serializable?` but Groovy fails to resolve the overloading when `null as Serializable` is passed as value
     ) = check(value is Serializable?) { "Value is not a Serializable: $value (${value!!::class.java.name})" }
-        .run { addField(typeOf(type), name, valueOf(value)) }
+        .run { addField(nameOf(type), name, valueOf(value)) }
 
 }

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
@@ -1,6 +1,7 @@
 package org.gradle.kotlin.dsl
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
+import com.github.gmazzo.buildconfig.BuildConfigDsl
 import com.github.gmazzo.buildconfig.addField
 import com.github.gmazzo.buildconfig.nameOf
 import com.github.gmazzo.buildconfig.valueOf
@@ -8,46 +9,54 @@ import org.gradle.api.provider.Provider
 import java.io.Serializable
 import kotlin.reflect.typeOf
 
+@BuildConfigDsl
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Type?,
 ) = addField(nameOf(typeOf<Type>()), name, valueOf(value))
 
+@BuildConfigDsl
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Type>,
 ) = addField(nameOf(typeOf<Type>()), name, value.map(::valueOf))
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Array<Type>,
 ) = addField(nameOf(typeOf<Array<Type>>()), name, valueOf(value))
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: List<Type>,
 ) = addField(nameOf(typeOf<List<Type>>()), name, valueOf(if (value is Serializable) value else ArrayList(value)))
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Set<Type>,
 ) = addField(nameOf(typeOf<Set<Type>>()), name, valueOf(if (value is Serializable) value else LinkedHashSet(value)))
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Array<Type>>,
 ) = addField(nameOf(typeOf<Array<Type>>()), name, value.map(::valueOf))
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out List<Type>>,
 ) = addField(nameOf(typeOf<List<Type>>()), name, value.map { valueOf(if (it is Serializable) it else ArrayList(it)) })
 
+@BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,

--- a/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtilsTests.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtilsTests.kt
@@ -1,28 +1,71 @@
 package com.github.gmazzo.buildconfig
 
-import com.github.gmazzo.buildconfig.BuildConfigType.NameRef
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class BuildConfigTypeUtilsTests {
 
-    private val paramsStringInt = listOf(NameRef("String"), NameRef("Int"))
-    private val paramsStringListOfInt = listOf(NameRef("String"), NameRef("List", listOf(NameRef("Int?"))))
+    private val string = BuildConfigType("String")
+    private val int = BuildConfigType("Int")
+    private val mapStringInt = BuildConfigType("java.util.Map", listOf(string, int))
+    private val mapStringListOfInt =
+        BuildConfigType("java.util.Map", listOf(string, BuildConfigType("List", listOf(int.copy(nullable = true)))))
 
     @Test
-    fun testNameOf() {
-        assertEquals(NameRef("String"), nameOf("String"))
-        assertEquals(NameRef("String?"), nameOf("String?"))
-        assertEquals(NameRef("String[]"), nameOf("String[]"))
-        assertEquals(NameRef("String?[]"), nameOf("String?[]"))
-        assertEquals(NameRef("Map", paramsStringInt), nameOf("Map<String, Int>"))
-        assertEquals(NameRef("Map?", paramsStringInt), nameOf("Map<String, Int>?"))
-        assertEquals(NameRef("Map[]", paramsStringInt), nameOf("Map<String, Int>[]"))
-        assertEquals(NameRef("Map?[]", paramsStringInt), nameOf("Map<String, Int>?[]"))
-        assertEquals(NameRef("Map", paramsStringListOfInt), nameOf("Map<String, List<Int?>>"))
-        assertEquals(NameRef("Map?", paramsStringListOfInt), nameOf("Map<String, List<Int?>>?"))
-        assertEquals(NameRef("Map[]", paramsStringListOfInt), nameOf("Map<String, List<Int?>>[]"))
-        assertEquals(NameRef("Map?[]", paramsStringListOfInt), nameOf("Map<String, List<Int?>>?[]"))
+    fun testNameOfByJavaClass() {
+        assertEquals(string, nameOf(String::class.java))
+        assertEquals(string.copy(array = true), nameOf(Array<String>::class.java))
+
+        assertEquals(int, nameOf(Int::class.java))
+        assertEquals(int.copy(array = true), nameOf(Array<Int>::class.java))
+        assertEquals(int.copy(array = true), nameOf(Array<Int?>::class.java))
+        assertEquals(int.copy(array = true), nameOf(IntArray::class.java))
+    }
+
+    @Test
+    fun testNameOfByKType() {
+        assertEquals(string, nameOf(typeOf<String>()))
+        assertEquals(string.copy(nullable = true), nameOf(typeOf<String?>()))
+        assertEquals(string.copy(array = true), nameOf(typeOf<Array<String>>()))
+        assertEquals(string.copy(nullable = true, array = true), nameOf(typeOf<Array<String?>>()))
+
+        assertEquals(int, nameOf(typeOf<Int>()))
+        assertEquals(int.copy(nullable = true), nameOf(typeOf<Int?>()))
+        assertEquals(int.copy(array = true), nameOf(typeOf<Array<Int>>()))
+        assertEquals(int.copy(array = true), nameOf(typeOf<IntArray>()))
+        assertEquals(int.copy(nullable = true, array = true), nameOf(typeOf<Array<Int?>>()))
+
+        assertEquals(mapStringInt, nameOf(typeOf<Map<String, Int>>()))
+        assertEquals(mapStringInt.copy(nullable = true), nameOf(typeOf<Map<String, Int>?>()))
+        assertEquals(mapStringInt.copy(array = true), nameOf(typeOf<Array<Map<String, Int>>>()))
+        assertEquals(mapStringInt.copy(nullable = true, array = true), nameOf(typeOf<Array<Map<String, Int>?>>()))
+
+        assertEquals(mapStringListOfInt, nameOf(typeOf<Map<String, List<Int?>>>()))
+        assertEquals(mapStringListOfInt.copy(nullable = true), nameOf(typeOf<Map<String, List<Int?>>?>()))
+        assertEquals(mapStringListOfInt.copy(array = true), nameOf(typeOf<Array<Map<String, List<Int?>>>>()))
+        assertEquals(
+            mapStringListOfInt.copy(nullable = true, array = true),
+            nameOf(typeOf<Array<Map<String, List<Int?>>?>>())
+        )
+    }
+
+    @Test
+    fun testNameOfByName() {
+        assertEquals(string, nameOf("String"))
+        assertEquals(string.copy(nullable = true), nameOf("String?"))
+        assertEquals(string.copy(array = true), nameOf("String[]"))
+        assertEquals(string.copy(nullable = true, array = true), nameOf("String?[]"))
+
+        assertEquals(mapStringInt, nameOf("java.util.Map<String, Int>"))
+        assertEquals(mapStringInt.copy(nullable = true), nameOf("java.util.Map<String, Int>?"))
+        assertEquals(mapStringInt.copy(array = true), nameOf("java.util.Map<String, Int>[]"))
+        assertEquals(mapStringInt.copy(nullable = true, array = true), nameOf("java.util.Map<String, Int>?[]"))
+
+        assertEquals(mapStringListOfInt, nameOf("java.util.Map<String, List<Int?>>"))
+        assertEquals(mapStringListOfInt.copy(nullable = true), nameOf("java.util.Map<String, List<Int?>>?"))
+        assertEquals(mapStringListOfInt.copy(array = true), nameOf("java.util.Map<String, List<Int?>>[]"))
+        assertEquals(mapStringListOfInt.copy(nullable = true, array = true), nameOf("java.util.Map<String, List<Int?>>?[]"))
     }
 
 }


### PR DESCRIPTION
Addressed issues with Configuration Cache, by basically dropping the `JavaRef` (`Type`) support and always using classes names.