### PR TITLE
Improved DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ buildConfig {
     buildConfigField("FEATURE_ENABLED", true)
     buildConfigField("MAGIC_NUMBERS", intArrayOf(1, 2, 3, 4))
     buildConfigField("STRING_LIST", arrayOf("a", "b", "c"))
-    buildConfigField("kotlin.collections.Map<String, Int>", "MAP", "mapOf(\"a\" to 1, \"b\" to 2)")
+    buildConfigField<Map<String, Int>>("MAP") {
+        expression("mapOf(\"a\" to 1, \"b\" to 2)")
+    }
     buildConfigField("com.github.gmazzo.buildconfig.demos.kts.SomeData", "DATA", "SomeData(\"a\", 1)")
 
 }

--- a/demo-project/generic/build.gradle.kts
+++ b/demo-project/generic/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.gmazzo.buildconfig.BuildConfigField
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -21,6 +22,13 @@ buildConfig {
     forClass("BuildResources") {
         buildConfigField("String","A_CONSTANT", "\"aConstant\"")
     }
+
+    buildConfigFields.addLater(provider {
+        objects.newInstance<BuildConfigField>("PROVIDED").apply {
+            type(String::class.java)
+            value("byAddLater")
+        }
+    })
 }
 
 // everything below here are just helper code to allow testing the plugin as we can't rely on any framework like JUnit
@@ -37,6 +45,8 @@ val generateBuildConfigTest = task<AssertGeneratedFile>("generateBuildConfigTest
         public final class BuildConfig {
           public static final String APP_NAME = "generic";
         
+          public static final String PROVIDED = "byAddLater";
+
           public static final String APP_SECRET = "Z3JhZGxlLWphdmEtYnVpbGRjb25maWctcGx1Z2lu";
         
           public static final long BUILD_TIME = 172800000;

--- a/demo-project/groovy-gen-kotlin/build.gradle
+++ b/demo-project/groovy-gen-kotlin/build.gradle
@@ -1,0 +1,183 @@
+plugins {
+    id 'java'
+    id 'com.github.gmazzo.buildconfig'
+    id 'java-test-fixtures'
+}
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
+
+dependencies {
+    implementation(projects.demoProject.groovy)
+    testImplementation(libs.kotlin.test)
+    testImplementation(testFixtures(projects.demoProject.groovy))
+}
+
+buildConfig {
+    useKotlinOutput()
+
+    documentation = "This is a generated BuildConfig class"
+    packageName("com.github.gmazzo.buildconfig.demos.groovy")
+
+    buildConfigField(String, 'APP_NAME', project.name)
+    buildConfigField(String, "APP_VERSION", provider { project.version })
+    buildConfigField(String, 'APP_SECRET', "Z3JhZGxlLWphdmEtYnVpbGRjb25maWctcGx1Z2lu")
+    buildConfigField(String, 'OPTIONAL', null)
+    buildConfigField(long, 'BUILD_TIME', System.currentTimeMillis())
+    buildConfigField(boolean, 'FEATURE_ENABLED', true)
+    buildConfigField('List<Int>', 'MAGIC_NUMBERS', [1, 2, 3])
+
+    // all possible kind for String
+    buildConfigField(String, "STRING", "aString")
+    buildConfigField(String, "STRING_NULL", null)
+    buildConfigField(String, "STRING_PROVIDER", provider { "aString" })
+    buildConfigField(String[], "STRING_ARRAY", ["a", "b", "c"])
+    buildConfigField(String[], "STRING_ARRAY_PROVIDER", provider { ["a", "b", "c"] })
+    buildConfigField(String[], "STRING_ARRAY_NULLABLE", ["a", null, "c"])
+    buildConfigField(String[], "STRING_ARRAY_NULLABLE_PROVIDER", provider { ["a", null, "c"] })
+    buildConfigField('List<String>', "STRING_LIST", ["a", null, "c"])
+    buildConfigField('List<String>', "STRING_LIST_PROVIDER", provider { ["a", null, "c"] })
+    buildConfigField('Set<String>', "STRING_SET", ["a", null, "c"])
+    buildConfigField('Set<String>', "STRING_SET_PROVIDER", provider { ["a", null, "c"] })
+
+    // all possible kind for Byte
+    buildConfigField(byte, "BYTE", 64 as byte)
+    buildConfigField(Byte, "BYTE_NULL", null)
+    buildConfigField(byte, "BYTE_PROVIDER", provider { 64 as byte })
+    buildConfigField(byte[], "BYTE_NATIVE_ARRAY", [1, 2, 3])
+    buildConfigField(byte[], "BYTE_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField(Byte[], "BYTE_ARRAY", [1, 2, 3])
+    buildConfigField(Byte[], "BYTE_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField('Byte?[]', "BYTE_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Byte?[]', "BYTE_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('List<Byte>', "BYTE_LIST", [1, null, 3])
+    buildConfigField('List<Byte>', "BYTE_LIST_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Set<Byte>', "BYTE_SET", [1, null, 3])
+    buildConfigField('Set<Byte>', "BYTE_SET_PROVIDER", provider { [1, null, 3] })
+
+    // all possible kind for Short
+    buildConfigField(short, "SHORT", 64)
+    buildConfigField(short, "SHORT_NULL", null)
+    buildConfigField(short, "SHORT_PROVIDER", provider { 64 })
+    buildConfigField(short[], "SHORT_NATIVE_ARRAY", [1, 2, 3])
+    buildConfigField(short[], "SHORT_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField(Short[], "SHORT_ARRAY", [1, 2, 3])
+    buildConfigField(Short[], "SHORT_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField('Short?[]', "SHORT_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Short?[]', "SHORT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('List<Short>', "SHORT_LIST", [1, null, 3])
+    buildConfigField('List<Short>', "SHORT_LIST_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Set<Short>', "SHORT_SET", [1, null, 3])
+    buildConfigField('Set<Short>', "SHORT_SET_PROVIDER", provider { [1, null, 3] })
+
+    // all possible kind for Char
+    buildConfigField(char, "CHAR", 'a' as char)
+    buildConfigField(Character, "CHAR_NULL", null)
+    buildConfigField(char, "CHAR_PROVIDER", provider { 'a' as char })
+    buildConfigField(char[], "CHAR_NATIVE_ARRAY", ['a' as char, 'b' as char, 'c' as char])
+    buildConfigField(char[], "CHAR_NATIVE_ARRAY_PROVIDER", provider { ['a' as char, 'b' as char, 'c' as char] })
+    buildConfigField(Character[], "CHAR_ARRAY", ['a' as char, 'b' as char, 'c' as char])
+    buildConfigField(Character[], "CHAR_ARRAY_PROVIDER", provider { ['a' as char, 'b' as char, 'c' as char] })
+    buildConfigField('Character?[]', "CHAR_ARRAY_NULLABLE", ['a' as char, null, 'c' as char])
+    buildConfigField('Character?[]', "CHAR_ARRAY_NULLABLE_PROVIDER", provider { ['a' as char, null, 'c' as char] })
+    buildConfigField('List<Character>', "CHAR_LIST", ['a' as char, null, 'c' as char])
+    buildConfigField('List<Character>', "CHAR_LIST_PROVIDER", provider { ['a' as char, null, 'c' as char] })
+    buildConfigField('Set<Character>', "CHAR_SET", ['a' as char, null, 'c' as char])
+    buildConfigField('Set<Character>', "CHAR_SET_PROVIDER", provider { ['a' as char, null, 'c' as char] })
+
+    // all possible kind for Int
+    buildConfigField(int, "INT", 1)
+    buildConfigField(Integer, "INT_NULL", null)
+    buildConfigField(int, "INT_PROVIDER", provider { 1 })
+    buildConfigField(int[], "INT_NATIVE_ARRAY", [1, 2, 3])
+    buildConfigField(int[], "INT_NATIVE_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField(Integer[], "INT_ARRAY", [1, 2, 3])
+    buildConfigField(Integer[], "INT_ARRAY_PROVIDER", provider { [1, 2, 3] })
+    buildConfigField('Integer?[]', "INT_ARRAY_NULLABLE", [1, null, 3])
+    buildConfigField('Integer?[]', "INT_ARRAY_NULLABLE_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('List<Integer>', "INT_LIST", [1, null, 3])
+    buildConfigField('List<Integer>', "INT_LIST_PROVIDER", provider { [1, null, 3] })
+    buildConfigField('Set<Integer>', "INT_SET", [1, null, 3])
+    buildConfigField('Set<Integer>', "INT_SET_PROVIDER", provider { [1, null, 3] })
+
+    // all possible kind for Long
+    buildConfigField(long, "LONG", 1L)
+    buildConfigField(Long, "LONG_NULL", null)
+    buildConfigField(long, "LONG_PROVIDER", provider { 1L })
+    buildConfigField(long[], "LONG_NATIVE_ARRAY", [1L, 2L, 3L])
+    buildConfigField(long[], "LONG_NATIVE_ARRAY_PROVIDER", provider { [1L, 2L, 3L] })
+    buildConfigField(Long[], "LONG_ARRAY", [1L, 2L, 3L])
+    buildConfigField(Long[], "LONG_ARRAY_PROVIDER", provider { [1L, 2L, 3L] })
+    buildConfigField('Long?[]', "LONG_ARRAY_NULLABLE", [1L, null, 3L])
+    buildConfigField('Long?[]', "LONG_ARRAY_NULLABLE_PROVIDER", provider { [1L, null, 3L] })
+    buildConfigField('List<Long>', "LONG_LIST", [1L, null, 3L])
+    buildConfigField('List<Long>', "LONG_LIST_PROVIDER", provider { [1L, null, 3L] })
+    buildConfigField('Set<Long>', "LONG_SET", [1L, null, 3L])
+    buildConfigField('Set<Long>', "LONG_SET_PROVIDER", provider { [1L, null, 3L] })
+
+    // all possible kind for Float
+    buildConfigField(float, "FLOAT", 1f)
+    buildConfigField(Float, "FLOAT_NULL", null)
+    buildConfigField(float, "FLOAT_PROVIDER", provider { 1f })
+    buildConfigField(float[], "FLOAT_NATIVE_ARRAY", [1f, 2f, 3f])
+    buildConfigField(float[], "FLOAT_NATIVE_ARRAY_PROVIDER", provider { [1f, 2f, 3f] })
+    buildConfigField(Float[], "FLOAT_ARRAY", [1f, 2f, 3f])
+    buildConfigField(Float[], "FLOAT_ARRAY_PROVIDER", provider { [1f, 2f, 3f] })
+    buildConfigField('Float?[]', "FLOAT_ARRAY_NULLABLE", [1f, null, 3f])
+    buildConfigField('Float?[]', "FLOAT_ARRAY_NULLABLE_PROVIDER", provider { [1f, null, 3f] })
+    buildConfigField('List<Float>', "FLOAT_LIST", [1f, null, 3f])
+    buildConfigField('List<Float>', "FLOAT_LIST_PROVIDER", provider { [1f, null, 3f] })
+    buildConfigField('Set<Float>', "FLOAT_SET", [1f, null, 3f])
+    buildConfigField('Set<Float>', "FLOAT_SET_PROVIDER", provider { [1f, null, 3f] })
+
+    // all possible kind for Double
+    buildConfigField(double, "DOUBLE", 1.0)
+    buildConfigField(Double, "DOUBLE_NULL", null)
+    buildConfigField(double, "DOUBLE_PROVIDER", provider { 1.0 })
+    buildConfigField(double[], "DOUBLE_NATIVE_ARRAY", [1.0, 2.0, 3.0])
+    buildConfigField(double[], "DOUBLE_NATIVE_ARRAY_PROVIDER", provider { [1.0, 2.0, 3.0] })
+    buildConfigField(Double[], "DOUBLE_ARRAY", [1.0, 2.0, 3.0])
+    buildConfigField(Double[], "DOUBLE_ARRAY_PROVIDER", provider { [1.0, 2.0, 3.0] })
+    buildConfigField('Double?[]', "DOUBLE_ARRAY_NULLABLE", [1.0, null, 3.0])
+    buildConfigField('Double?[]', "DOUBLE_ARRAY_NULLABLE_PROVIDER", provider { [1.0, null, 3.0] })
+    buildConfigField('List<Double>', "DOUBLE_LIST", [1.0, null, 3.0])
+    buildConfigField('List<Double>', "DOUBLE_LIST_PROVIDER", provider { [1.0, null, 3.0] })
+    buildConfigField('Set<Double>', "DOUBLE_SET", [1.0, null, 3.0])
+    buildConfigField('Set<Double>', "DOUBLE_SET_PROVIDER", provider { [1.0, null, 3.0] })
+
+    // all possible kind for Boolean
+    buildConfigField(boolean, "BOOLEAN", true)
+    buildConfigField(Boolean, "BOOLEAN_NULL", null)
+    buildConfigField(boolean, "BOOLEAN_PROVIDER", provider { true })
+    buildConfigField(boolean[], "BOOLEAN_NATIVE_ARRAY", [true, false, false])
+    buildConfigField(boolean[], "BOOLEAN_NATIVE_ARRAY_PROVIDER", provider { [true, false, false] })
+    buildConfigField(Boolean[], "BOOLEAN_ARRAY", [true, false, false])
+    buildConfigField(Boolean[], "BOOLEAN_ARRAY_PROVIDER", provider { [true, false, false] })
+    buildConfigField('Boolean?[]', "BOOLEAN_ARRAY_NULLABLE", [true, null, false])
+    buildConfigField('Boolean?[]', "BOOLEAN_ARRAY_NULLABLE_PROVIDER", provider { [true, null, false] })
+    buildConfigField('List<Boolean>', "BOOLEAN_LIST", [true, null, false])
+    buildConfigField('List<Boolean>', "BOOLEAN_LIST_PROVIDER", provider { [true, null, false] })
+    buildConfigField('Set<Boolean>', "BOOLEAN_SET", [true, null, false])
+    buildConfigField('Set<Boolean>', "BOOLEAN_SET_PROVIDER", provider { [true, null, false] })
+
+    // custom formats with expressions, including Map and custom types
+    buildConfigField(
+            "Map<String, Integer>",
+            "MAP",
+            "mapOf(\"a\" to 1, \"b\" to 2)"
+    )
+    buildConfigField(
+            "Map<String, Integer>",
+            "MAP_PROVIDER",
+            provider { "mapOf(\"a\" to 1, \"b\" to 2)" }
+    )
+    buildConfigField(
+            "com.github.gmazzo.buildconfig.demos.groovy.SomeData",
+            "DATA",
+            "new SomeData(\"a\", 1)"
+    )
+    buildConfigField(
+            "com.github.gmazzo.buildconfig.demos.groovy.SomeData",
+            "DATA_PROVIDER",
+            provider { "new SomeData(\"a\", 1)" }
+    )
+}

--- a/demo-project/groovy-gen-kotlin/src/test/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigTest.java
+++ b/demo-project/groovy-gen-kotlin/src/test/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigTest.java
@@ -1,0 +1,4 @@
+package com.github.gmazzo.buildconfig.demos.groovy;
+
+public class BuildConfigTest extends BuildConfigBaseTest {
+}

--- a/demo-project/groovy/build.gradle
+++ b/demo-project/groovy/build.gradle
@@ -1,3 +1,5 @@
+import com.github.gmazzo.buildconfig.BuildConfigField
+
 plugins {
     id 'java'
     id 'com.github.gmazzo.buildconfig'
@@ -198,9 +200,17 @@ sourceSets {
 buildConfig.forClass("BuildResources") {
     buildConfigField('String', 'A_CONSTANT', '"aConstant"')
 
-    sourceSets.main.resources.asFileTree.visit {
-        def name = it.path.toUpperCase().replaceAll("\\W", "_")
+    def files = sourceSets.main.resources.sourceDirectories.asFileTree
+    buildConfigFields.addAllLater(provider {
+        List<BuildConfigField> fields = []
+        files.asFileTree.visit {
+            def name = it.path.toUpperCase().replaceAll("\\W", "_")
 
-        buildConfigField('java.io.File', name, "new File(\"${it.path}\")")
-    }
+            fields.add(objects.newInstance(BuildConfigField, name).with { _ ->
+                type(File)
+                expression("new File(\"${it.path}\")")
+            })
+        }
+        return fields
+    })
 }

--- a/demo-project/kts-gen-java/build.gradle.kts
+++ b/demo-project/kts-gen-java/build.gradle.kts
@@ -1,0 +1,180 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    id("com.github.gmazzo.buildconfig")
+}
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(libs.versions.java.get())
+
+dependencies {
+    implementation(projects.demoProject.kts)
+    testImplementation(libs.kotlin.test)
+    testImplementation(testFixtures(projects.demoProject.groovy))
+}
+
+buildConfig {
+    useJavaOutput()
+    documentation = "This is a generated BuildConfig class"
+
+    buildConfigField("APP_NAME", project.name)
+    buildConfigField("APP_VERSION", provider { "\"${project.version}\"" })
+    buildConfigField("APP_SECRET", "Z3JhZGxlLWphdmEtYnVpbGRjb25maWctcGx1Z2lu")
+    buildConfigField<String>("OPTIONAL", null)
+    buildConfigField("BUILD_TIME", System.currentTimeMillis())
+    buildConfigField("FEATURE_ENABLED", true)
+    buildConfigField("MAGIC_NUMBERS", listOf(1, 2, 3))
+
+    // all possible kind for String
+    buildConfigField("STRING", "aString")
+    buildConfigField("STRING_NULL", null as String?)
+    buildConfigField("STRING_PROVIDER", provider { "aString" })
+    buildConfigField("STRING_ARRAY", arrayOf("a", "b", "c"))
+    buildConfigField("STRING_ARRAY_PROVIDER", provider { arrayOf("a", "b", "c") })
+    buildConfigField("STRING_ARRAY_NULLABLE", arrayOf("a", null, "c"))
+    buildConfigField("STRING_ARRAY_NULLABLE_PROVIDER", provider { arrayOf("a", null, "c") })
+    buildConfigField("STRING_LIST", listOf("a", null, "c"))
+    buildConfigField("STRING_LIST_PROVIDER", provider { listOf("a", null, "c") })
+    buildConfigField("STRING_SET", setOf("a", null, "c"))
+    buildConfigField("STRING_SET_PROVIDER", provider { setOf("a", null, "c") })
+
+    // all possible kind for Byte
+    buildConfigField("BYTE", 64.toByte())
+    buildConfigField("BYTE_NULL", null as Byte?)
+    buildConfigField("BYTE_PROVIDER", provider { 64.toByte() })
+    buildConfigField("BYTE_NATIVE_ARRAY", byteArrayOf(1, 2, 3))
+    buildConfigField("BYTE_NATIVE_ARRAY_PROVIDER", provider { byteArrayOf(1, 2, 3) })
+    buildConfigField("BYTE_ARRAY", arrayOf(1.toByte(), 2.toByte(), 3.toByte()))
+    buildConfigField("BYTE_ARRAY_PROVIDER", provider { arrayOf(1.toByte(), 2.toByte(), 3.toByte()) })
+    buildConfigField("BYTE_ARRAY_NULLABLE", arrayOf(1.toByte(), null, 3.toByte()))
+    buildConfigField("BYTE_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1.toByte(), null, 3.toByte()) })
+    buildConfigField("BYTE_LIST", listOf(1.toByte(), null, 3.toByte()))
+    buildConfigField("BYTE_LIST_PROVIDER", provider { listOf(1.toByte(), null, 3.toByte()) })
+    buildConfigField("BYTE_SET", setOf(1.toByte(), null, 3.toByte()))
+    buildConfigField("BYTE_SET_PROVIDER", provider { setOf(1.toByte(), null, 3.toByte()) })
+
+    // all possible kind for Short
+    buildConfigField("SHORT", 64.toShort())
+    buildConfigField("SHORT_NULL", null as Short?)
+    buildConfigField("SHORT_PROVIDER", provider { 64.toShort() })
+    buildConfigField("SHORT_NATIVE_ARRAY", shortArrayOf(1, 2, 3))
+    buildConfigField("SHORT_NATIVE_ARRAY_PROVIDER", provider { shortArrayOf(1, 2, 3) })
+    buildConfigField("SHORT_ARRAY", arrayOf(1.toShort(), 2.toShort(), 3.toShort()))
+    buildConfigField("SHORT_ARRAY_PROVIDER", provider { arrayOf(1.toShort(), 2.toShort(), 3.toShort()) })
+    buildConfigField("SHORT_ARRAY_NULLABLE", arrayOf(1.toShort(), null, 3.toShort()))
+    buildConfigField("SHORT_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1.toShort(), null, 3.toShort()) })
+    buildConfigField("SHORT_LIST", listOf(1.toShort(), null, 3.toShort()))
+    buildConfigField("SHORT_LIST_PROVIDER", provider { listOf(1.toShort(), null, 3.toShort()) })
+    buildConfigField("SHORT_SET", setOf(1.toShort(), null, 3.toShort()))
+    buildConfigField("SHORT_SET_PROVIDER", provider { setOf(1.toShort(), null, 3.toShort()) })
+
+    // all possible kind for Char
+    buildConfigField("CHAR", 'a')
+    buildConfigField("CHAR_NULL", null as Char?)
+    buildConfigField("CHAR_PROVIDER", provider { 'a' })
+    buildConfigField("CHAR_NATIVE_ARRAY", charArrayOf('a', 'b', 'c'))
+    buildConfigField("CHAR_NATIVE_ARRAY_PROVIDER", provider { charArrayOf('a', 'b', 'c') })
+    buildConfigField("CHAR_ARRAY", arrayOf('a', 'b', 'c'))
+    buildConfigField("CHAR_ARRAY_PROVIDER", provider { arrayOf('a', 'b', 'c') })
+    buildConfigField("CHAR_ARRAY_NULLABLE", arrayOf('a', null, 'c'))
+    buildConfigField("CHAR_ARRAY_NULLABLE_PROVIDER", provider { arrayOf('a', null, 'c') })
+    buildConfigField("CHAR_LIST", listOf('a', null, 'c'))
+    buildConfigField("CHAR_LIST_PROVIDER", provider { listOf('a', null, 'c') })
+    buildConfigField("CHAR_SET", setOf('a', null, 'c'))
+    buildConfigField("CHAR_SET_PROVIDER", provider { setOf('a', null, 'c') })
+
+    // all possible kind for Int
+    buildConfigField("INT", 1)
+    buildConfigField("INT_NULL", null as Int?)
+    buildConfigField("INT_PROVIDER", provider { 1 })
+    buildConfigField("INT_NATIVE_ARRAY", intArrayOf(1, 2, 3))
+    buildConfigField("INT_NATIVE_ARRAY_PROVIDER", provider { intArrayOf(1, 2, 3) })
+    buildConfigField("INT_ARRAY", arrayOf(1, 2, 3))
+    buildConfigField("INT_ARRAY_PROVIDER", provider { arrayOf(1, 2, 3) })
+    buildConfigField("INT_ARRAY_NULLABLE", arrayOf(1, null, 3))
+    buildConfigField("INT_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1, null, 3) })
+    buildConfigField("INT_LIST", listOf(1, null, 3))
+    buildConfigField("INT_LIST_PROVIDER", provider { listOf(1, null, 3) })
+    buildConfigField("INT_SET", setOf(1, null, 3))
+    buildConfigField("INT_SET_PROVIDER", provider { setOf(1, null, 3) })
+
+    // all possible kind for Long
+    buildConfigField("LONG", 1L)
+    buildConfigField("LONG_NULL", null as Long?)
+    buildConfigField("LONG_PROVIDER", provider { 1L })
+    buildConfigField("LONG_NATIVE_ARRAY", longArrayOf(1L, 2L, 3L))
+    buildConfigField("LONG_NATIVE_ARRAY_PROVIDER", provider { longArrayOf(1L, 2L, 3L) })
+    buildConfigField("LONG_ARRAY", arrayOf(1L, 2L, 3L))
+    buildConfigField("LONG_ARRAY_PROVIDER", provider { arrayOf(1L, 2L, 3L) })
+    buildConfigField("LONG_ARRAY_NULLABLE", arrayOf(1L, null, 3L))
+    buildConfigField("LONG_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1L, null, 3L) })
+    buildConfigField("LONG_LIST", listOf(1L, null, 3L))
+    buildConfigField("LONG_LIST_PROVIDER", provider { listOf(1L, null, 3L) })
+    buildConfigField("LONG_SET", setOf(1L, null, 3L))
+    buildConfigField("LONG_SET_PROVIDER", provider { setOf(1L, null, 3L) })
+
+    // all possible kind for Float
+    buildConfigField("FLOAT", 1f)
+    buildConfigField("FLOAT_NULL", null as Float?)
+    buildConfigField("FLOAT_PROVIDER", provider { 1f })
+    buildConfigField("FLOAT_NATIVE_ARRAY", floatArrayOf(1f, 2f, 3f))
+    buildConfigField("FLOAT_NATIVE_ARRAY_PROVIDER", provider { floatArrayOf(1f, 2f, 3f) })
+    buildConfigField("FLOAT_ARRAY", arrayOf(1f, 2f, 3f))
+    buildConfigField("FLOAT_ARRAY_PROVIDER", provider { arrayOf(1f, 2f, 3f) })
+    buildConfigField("FLOAT_ARRAY_NULLABLE", arrayOf(1f, null, 3f))
+    buildConfigField("FLOAT_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1f, null, 3f) })
+    buildConfigField("FLOAT_LIST", listOf(1f, null, 3f))
+    buildConfigField("FLOAT_LIST_PROVIDER", provider { listOf(1f, null, 3f) })
+    buildConfigField("FLOAT_SET", setOf(1f, null, 3f))
+    buildConfigField("FLOAT_SET_PROVIDER", provider { setOf(1f, null, 3f) })
+
+    // all possible kind for Double
+    buildConfigField("DOUBLE", 1.0)
+    buildConfigField("DOUBLE_NULL", null as Double?)
+    buildConfigField("DOUBLE_PROVIDER", provider { 1.0 })
+    buildConfigField("DOUBLE_NATIVE_ARRAY", doubleArrayOf(1.0, 2.0, 3.0))
+    buildConfigField("DOUBLE_NATIVE_ARRAY_PROVIDER", provider { doubleArrayOf(1.0, 2.0, 3.0) })
+    buildConfigField("DOUBLE_ARRAY", arrayOf(1.0, 2.0, 3.0))
+    buildConfigField("DOUBLE_ARRAY_PROVIDER", provider { arrayOf(1.0, 2.0, 3.0) })
+    buildConfigField("DOUBLE_ARRAY_NULLABLE", arrayOf(1.0, null, 3.0))
+    buildConfigField("DOUBLE_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(1.0, null, 3.0) })
+    buildConfigField("DOUBLE_LIST", listOf(1.0, null, 3.0))
+    buildConfigField("DOUBLE_LIST_PROVIDER", provider { listOf(1.0, null, 3.0) })
+    buildConfigField("DOUBLE_SET", setOf(1.0, null, 3.0))
+    buildConfigField("DOUBLE_SET_PROVIDER", provider { setOf(1.0, null, 3.0) })
+
+    // all possible kind for Boolean
+    buildConfigField("BOOLEAN", true)
+    buildConfigField("BOOLEAN_NULL", null as Boolean?)
+    buildConfigField("BOOLEAN_PROVIDER", provider { true })
+    buildConfigField("BOOLEAN_NATIVE_ARRAY", booleanArrayOf(true, false, false))
+    buildConfigField("BOOLEAN_NATIVE_ARRAY_PROVIDER", provider { booleanArrayOf(true, false, false) })
+    buildConfigField("BOOLEAN_ARRAY", arrayOf(true, false, false))
+    buildConfigField("BOOLEAN_ARRAY_PROVIDER", provider { arrayOf(true, false, false) })
+    buildConfigField("BOOLEAN_ARRAY_NULLABLE", arrayOf(true, null, false))
+    buildConfigField("BOOLEAN_ARRAY_NULLABLE_PROVIDER", provider { arrayOf(true, null, false) })
+    buildConfigField("BOOLEAN_LIST", listOf(true, null, false))
+    buildConfigField("BOOLEAN_LIST_PROVIDER", provider { listOf(true, null, false) })
+    buildConfigField("BOOLEAN_SET", setOf(true, null, false))
+    buildConfigField("BOOLEAN_SET_PROVIDER", provider { setOf(true, null, false) })
+
+    // custom formats with expressions, including Map and custom types
+    buildConfigField(
+        "java.util.Map<String, Int>",
+        "MAP",
+        "java.util.Map.of(\"a\", 1, \"b\", 2)"
+    )
+    buildConfigField(
+        "java.util.Map<String, Int>",
+        "MAP_PROVIDER",
+        provider { "java.util.Map.of(\"a\", 1, \"b\", 2)" }
+    )
+    buildConfigField(
+        "com.github.gmazzo.buildconfig.demos.kts.SomeData",
+        "DATA",
+        "new SomeData(\"a\", 1)"
+    )
+    buildConfigField(
+        "com.github.gmazzo.buildconfig.demos.kts.SomeData",
+        "DATA_PROVIDER",
+        provider { "new SomeData(\"a\", 1)" }
+    )
+}

--- a/demo-project/kts-gen-java/src/test/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigTest.java
+++ b/demo-project/kts-gen-java/src/test/java/com/github/gmazzo/buildconfig/demos/groovy/BuildConfigTest.java
@@ -1,0 +1,4 @@
+package com.github.gmazzo.buildconfig.demos.groovy;
+
+public class BuildConfigTest extends BuildConfigBaseTest {
+}

--- a/demo-project/kts/build.gradle.kts
+++ b/demo-project/kts/build.gradle.kts
@@ -172,16 +172,12 @@ buildConfig {
     buildConfigField("BOOLEAN_SET_PROVIDER", provider { setOf(true, null, false) })
 
     // custom formats with expressions, including Map and custom types
-    buildConfigField(
-        "kotlin.collections.Map<String, Int>",
-        "MAP",
-        "mapOf(\"a\" to 1, \"b\" to 2)"
-    )
-    buildConfigField(
-        "kotlin.collections.Map<String, Int>",
-        "MAP_PROVIDER",
-        provider { "mapOf(\"a\" to 1, \"b\" to 2)" }
-    )
+    buildConfigField<Map<String, Int>>("MAP")  {
+        expression("mapOf(\"a\" to 1, \"b\" to 2)")
+    }
+    buildConfigField<Map<String, Int>>("MAP_PROVIDER") {
+        expression("mapOf(\"a\" to 1, \"b\" to 2)")
+    }
     buildConfigField(
         "com.github.gmazzo.buildconfig.demos.kts.SomeData",
         "DATA",
@@ -216,8 +212,8 @@ buildConfig.forClass("BuildResources") {
         files.visit {
             val name = path.uppercase().replace("\\W".toRegex(), "_")
 
-            fields.add(objects.newInstance<BuildConfigField>( name).apply {
-                type(File::class.java)
+            fields.add(objects.newInstance<BuildConfigField>(name).apply {
+                type(File::class)
                 expression("File(\"$path\")")
             })
         }

--- a/demo-project/kts/build.gradle.kts
+++ b/demo-project/kts/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.gmazzo.buildconfig.BuildConfigField
 import com.github.gmazzo.buildconfig.BuildConfigValue
 import com.github.gmazzo.buildconfig.generators.BuildConfigGenerator
 import com.github.gmazzo.buildconfig.generators.BuildConfigGeneratorSpec
@@ -209,11 +210,19 @@ val versionsSS = buildConfig.sourceSets.register("Versions") {
 buildConfig.forClass("BuildResources") {
     buildConfigField("A_CONSTANT", "aConstant")
 
-    sourceSets["main"].resources.asFileTree.visit {
-        val name = path.uppercase().replace("\\W".toRegex(), "_")
+    val files = sourceSets["main"].resources.sourceDirectories.asFileTree
+    buildConfigFields.addAllLater(provider {
+        val fields = mutableListOf<BuildConfigField>()
+        files.visit {
+            val name = path.uppercase().replace("\\W".toRegex(), "_")
 
-        buildConfigField("java.io.File", name, "File(\"$path\")")
-    }
+            fields.add(objects.newInstance<BuildConfigField>( name).apply {
+                type(File::class.java)
+                expression("File(\"$path\")")
+            })
+        }
+        fields
+    })
 }
 
 // example of a custom generator that builds into XML

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -55,7 +55,7 @@ gradlePlugin {
 tasks.withType<Test> {
     workingDir = temporaryDir
     useJUnitPlatform()
-    doLast { Thread.sleep(2000) } // allows GradleRunner to store JaCoCo data before computing task outputs
+    doLast { Thread.sleep(5000) } // allows GradleRunner to store JaCoCo data before computing task outputs
 }
 
 tasks.check {

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigClassSpec.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigClassSpec.kt
@@ -1,8 +1,10 @@
 package com.github.gmazzo.buildconfig
 
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToType
+import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
@@ -47,30 +49,58 @@ interface BuildConfigClassSpec : Named {
         type: String,
         name: String,
         value: String,
-    ) = addField(nameOf(type), name, expressionOf(value))
+    ) = buildConfigField(nameOf(type), name, expressionOf(value))
 
     fun buildConfigField(
         type: String,
         name: String,
         value: Serializable?,
-    ) = addField(nameOf(type), name, valueOf(value))
+    ) = buildConfigField(nameOf(type), name, valueOf(value))
 
     fun <Type : Serializable> buildConfigField(
         type: Class<out Type>,
         name: String,
         value: Type?,
-    ) = addField(nameOf(type), name, valueOf(castToType(value, type) as Serializable))
+    ) = buildConfigField(nameOf(type), name, valueOf(castToType(value, type) as Serializable))
 
     fun buildConfigField(
         type: String,
         name: String,
         value: Provider<out Serializable>
-    ) = addField(nameOf(type), name, value.map { if (it is String) expressionOf(it) else valueOf(it) })
+    ) = buildConfigField(nameOf(type), name, value.map { if (it is String) expressionOf(it) else valueOf(it) })
 
     fun <Type : Serializable> buildConfigField(
         type: Class<out Type>,
         name: String,
         value: Provider<out Type>,
-    ) = addField(nameOf(type), name, value.map { valueOf(castToType(it, type) as Serializable) })
+    ) = buildConfigField(nameOf(type), name, value.map { valueOf(castToType(it, type) as Serializable) })
+
+    fun buildConfigField(
+        type: BuildConfigType,
+        name: String,
+        value: BuildConfigValue,
+    ) = buildConfigField(name) {
+        it.type.value(type).disallowChanges()
+        it.value.value(value).disallowChanges()
+    }
+
+    fun buildConfigField(
+        type: BuildConfigType,
+        name: String,
+        value: Provider<BuildConfigValue>
+    ) = buildConfigField(name) {
+        it.type.value(type).disallowChanges()
+        it.value.value(value).disallowChanges()
+    }
+
+    fun buildConfigField(
+        name: String,
+        configure: Action<BuildConfigField>
+    ): NamedDomainObjectProvider<BuildConfigField> = buildConfigFields.size.let { position ->
+        buildConfigFields.register(name) {
+            it.position.convention(position)
+            configure.execute(it)
+        }
+    }
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import java.io.Serializable
 import java.lang.reflect.Type
+import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 interface BuildConfigField : Named {
@@ -38,6 +39,10 @@ interface BuildConfigField : Named {
 
     fun type(type: Type) = apply {
         this.type.value(nameOf(type)).disallowChanges()
+    }
+
+    fun type(type: KClass<*>) = apply {
+        type(type.java)
     }
 
     fun type(type: KType) = apply {

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigField.kt
@@ -2,8 +2,12 @@ package com.github.gmazzo.buildconfig
 
 import org.gradle.api.Named
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+import java.io.Serializable
+import java.lang.reflect.Type
+import kotlin.reflect.KType
 
 interface BuildConfigField : Named {
 
@@ -19,5 +23,41 @@ interface BuildConfigField : Named {
     @get:Input
     @get:Optional
     val position: Property<Int>
+
+    fun type(classLiteral: String) = apply {
+        this.type.value(nameOf(classLiteral)).disallowChanges()
+    }
+
+    fun type(className: String, vararg typeArguments: String) = apply {
+        this.type.value(BuildConfigType(className, typeArguments.map(::nameOf).toList())).disallowChanges()
+    }
+
+    fun type(className: String, vararg typeArguments: BuildConfigType) = apply {
+        this.type.value(BuildConfigType(className, typeArguments.toList())).disallowChanges()
+    }
+
+    fun type(type: Type) = apply {
+        this.type.value(nameOf(type)).disallowChanges()
+    }
+
+    fun type(type: KType) = apply {
+        this.type.value(nameOf(type)).disallowChanges()
+    }
+
+    fun value(literal: Serializable?) = apply {
+        value.value(BuildConfigValue.Literal(literal)).disallowChanges()
+    }
+
+    fun <Type : Serializable> value(literal: Provider<out Type>) = apply {
+        value.value(literal.map(BuildConfigValue::Literal)).disallowChanges()
+    }
+
+    fun expression(expression: String) = apply {
+        value.value(BuildConfigValue.Expression(expression)).disallowChanges()
+    }
+
+    fun expression(expression: Provider<String>) = apply {
+        value.value(expression.map(BuildConfigValue::Expression)).disallowChanges()
+    }
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
@@ -1,7 +1,6 @@
 package com.github.gmazzo.buildconfig
 
 import org.jetbrains.annotations.VisibleForTesting
-import java.io.Serializable
 import java.lang.reflect.GenericArrayType
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -72,7 +71,6 @@ internal fun nameOf(type: Type): BuildConfigType = when(type) {
     else -> error("Unsupported type: $type")
 }
 
-@PublishedApi
 internal fun nameOf(type: KType): BuildConfigType {
     val isArray = type.javaType.isArray
     val targetType = type.takeIf { isArray }?.arguments?.singleOrNull()?.type ?: type
@@ -123,14 +121,6 @@ private fun parseName(
     val (typeName, nullable, array) = name.parseTypename()
     return BuildConfigType(typeName, parameters, nullable, array)
 }
-
-@PublishedApi
-internal fun expressionOf(expression: String) =
-    BuildConfigValue.Expression(expression)
-
-@PublishedApi
-internal fun valueOf(value: Serializable?) =
-    BuildConfigValue.Literal(value)
 
 internal val Any?.elements: List<Any?>
     get() = when (this) {

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTypeUtils.kt
@@ -1,7 +1,5 @@
 package com.github.gmazzo.buildconfig
 
-import org.gradle.api.NamedDomainObjectProvider
-import org.gradle.api.provider.Provider
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.Serializable
 import java.lang.reflect.GenericArrayType
@@ -133,30 +131,6 @@ internal fun expressionOf(expression: String) =
 @PublishedApi
 internal fun valueOf(value: Serializable?) =
     BuildConfigValue.Literal(value)
-
-private fun BuildConfigClassSpec.buildConfigField(
-    type: BuildConfigType,
-    name: String,
-    action: (BuildConfigField) -> Unit,
-): NamedDomainObjectProvider<BuildConfigField> = buildConfigFields.size.let { position ->
-    buildConfigFields.register(name) {
-        it.type.value(type).disallowChanges()
-        it.position.convention(position)
-        action(it)
-    }
-}
-
-@PublishedApi
-internal fun BuildConfigClassSpec.addField(type: BuildConfigType, name: String, value: BuildConfigValue) =
-    buildConfigField(type, name) { it.value.value(value).disallowChanges() }
-
-@PublishedApi
-internal fun BuildConfigClassSpec.addField(
-    type: BuildConfigType,
-    name: String,
-    value: Provider<BuildConfigValue>
-) =
-    buildConfigField(type, name) { it.value.value(value).disallowChanges() }
 
 internal val Any?.elements: List<Any?>
     get() = when (this) {

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/generators/BuildConfigKotlinGenerator.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/generators/BuildConfigKotlinGenerator.kt
@@ -91,7 +91,8 @@ data class BuildConfigKotlinGenerator(
     }
 
     private fun BuildConfigType.toTypeName(): TypeName {
-        var type: TypeName = when (className.lowercase()) {
+        val kotlinClassName = runCatching { Class.forName(className).kotlin.qualifiedName!! }.getOrDefault(className)
+        var type: TypeName = when (kotlinClassName.lowercase()) {
             "boolean" -> if (array && !nullable) BOOLEAN_ARRAY else BOOLEAN
             "byte" -> if (array && !nullable) BYTE_ARRAY else BYTE
             "short" -> if (array && !nullable) SHORT_ARRAY else SHORT
@@ -104,7 +105,7 @@ data class BuildConfigKotlinGenerator(
             "string" -> STRING
             "list" -> LIST
             "set" -> SET
-            else -> ClassName.bestGuess(className)
+            else -> ClassName.bestGuess(kotlinClassName)
         }
         if (typeArguments.isNotEmpty())
             type = (type as ClassName).parameterizedBy(*typeArguments.map { it.toTypeName() }.toTypedArray())

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
@@ -1,10 +1,7 @@
 package com.github.gmazzo.buildconfig.internal
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
-import com.github.gmazzo.buildconfig.nameOf
-import com.github.gmazzo.buildconfig.valueOf
 import groovy.lang.GroovyObjectSupport
-import java.io.Serializable
 
 /**
  * Workaround for Groovy's `null` value issue when calling overloaded methods limitation:
@@ -17,11 +14,15 @@ import java.io.Serializable
  */
 internal abstract class GroovyNullValueWorkaround : BuildConfigClassSpec, GroovyObjectSupport() {
 
-    fun <Type : Serializable> buildConfigField(
-        type: Class<out Type>,
+    fun buildConfigField(
+        type: Class<*>,
         name: String,
-        value: Any?, // this should be `Serializable?` but Groovy fails to resolve the overloading when `null as Serializable` is passed as value
-    ) = check(value == null) { "Only `null` values expected here, please fill a bug" }
-        .run { buildConfigField(nameOf(type), name, valueOf(null)) }
+        value: Any?,
+    ) = check(value == null) { "Only `null` values expected here, please fill a bug" }.run {
+        buildConfigField(name) {
+            it.type(type)
+            it.value(null)
+        }
+    }
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
@@ -1,7 +1,6 @@
 package com.github.gmazzo.buildconfig.internal
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
-import com.github.gmazzo.buildconfig.addField
 import com.github.gmazzo.buildconfig.nameOf
 import com.github.gmazzo.buildconfig.valueOf
 import groovy.lang.GroovyObjectSupport
@@ -22,7 +21,7 @@ internal abstract class GroovyNullValueWorkaround : BuildConfigClassSpec, Groovy
         type: Class<out Type>,
         name: String,
         value: Any?, // this should be `Serializable?` but Groovy fails to resolve the overloading when `null as Serializable` is passed as value
-    ) = check(value is Serializable?) { "Value is not a Serializable: $value (${value!!::class.java.name})" }
-        .run { addField(nameOf(type), name, valueOf(value)) }
+    ) = check(value == null) { "Only `null` values expected here, please fill a bug" }
+        .run { buildConfigField(nameOf(type), name, valueOf(null)) }
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/GroovyNullValueWorkaround.kt
@@ -1,7 +1,6 @@
 package com.github.gmazzo.buildconfig.internal
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
-import groovy.lang.GroovyObjectSupport
 
 /**
  * Workaround for Groovy's `null` value issue when calling overloaded methods limitation:
@@ -12,7 +11,7 @@ import groovy.lang.GroovyObjectSupport
  *   	[class java.lang.Class, class java.lang.String, interface org.gradle.api.provider.Provider]
  * ```
  */
-internal abstract class GroovyNullValueWorkaround : BuildConfigClassSpec, GroovyObjectSupport() {
+internal abstract class GroovyNullValueWorkaround : BuildConfigClassSpec {
 
     fun buildConfigField(
         type: Class<*>,

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
@@ -2,8 +2,9 @@ package org.gradle.kotlin.dsl
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
 import com.github.gmazzo.buildconfig.BuildConfigDsl
-import com.github.gmazzo.buildconfig.nameOf
-import com.github.gmazzo.buildconfig.valueOf
+import com.github.gmazzo.buildconfig.BuildConfigField
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.provider.Provider
 import java.io.Serializable
 import kotlin.reflect.typeOf
@@ -12,52 +13,76 @@ import kotlin.reflect.typeOf
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Type?,
-) = buildConfigField(nameOf(typeOf<Type>()), name, valueOf(value))
+): NamedDomainObjectProvider<BuildConfigField> = buildConfigField(name, Action {
+    it.type(typeOf<Type>())
+    it.value(value)
+})
 
 @BuildConfigDsl
-inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
+inline fun <reified Type : Serializable> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Type>,
-) = buildConfigField(nameOf(typeOf<Type>()), name, value.map(::valueOf))
+) = buildConfigField(name, Action {
+    it.type(typeOf<Type>())
+    it.value(value)
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Array<Type>,
-) = buildConfigField(nameOf(typeOf<Array<Type>>()), name, valueOf(value))
+) = buildConfigField(name, Action {
+    it.type(typeOf<Array<Type>>())
+    it.value(value)
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: List<Type>,
-) = buildConfigField(nameOf(typeOf<List<Type>>()), name, valueOf(if (value is Serializable) value else ArrayList(value)))
+) = buildConfigField(name, Action {
+    it.type(typeOf<List<Type>>())
+    it.value(if (value is Serializable) value else ArrayList(value))
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Set<Type>,
-) = buildConfigField(nameOf(typeOf<Set<Type>>()), name, valueOf(if (value is Serializable) value else LinkedHashSet(value)))
+) = buildConfigField(name, Action {
+    it.type(typeOf<Set<Type>>())
+    it.value(if (value is Serializable) value else LinkedHashSet(value))
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
-    value: Provider<out Array<Type>>,
-) = buildConfigField(nameOf(typeOf<Array<Type>>()), name, value.map(::valueOf))
+    value: Provider<Array<Type>>,
+) = buildConfigField(name, Action {
+    it.type(typeOf<Array<Type>>())
+    it.value(value)
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out List<Type>>,
-) = buildConfigField(nameOf(typeOf<List<Type>>()), name, value.map { valueOf(if (it is Serializable) it else ArrayList(it)) })
+) = buildConfigField(name, Action {
+    it.type(typeOf<List<Type>>())
+    it.value(value.map(::ArrayList))
+})
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Set<Type>>,
-) = buildConfigField(nameOf(typeOf<Set<Type>>()), name, value.map { valueOf(if (it is Serializable) it else LinkedHashSet(it)) })
+) = buildConfigField(name, Action {
+    it.type(typeOf<Set<Type>>())
+    it.value(value.map(::LinkedHashSet))
+})

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
@@ -10,6 +10,15 @@ import java.io.Serializable
 import kotlin.reflect.typeOf
 
 @BuildConfigDsl
+inline fun <reified Type : Any> BuildConfigClassSpec.buildConfigField(
+    name: String,
+    crossinline configure: BuildConfigField.() -> Unit
+): NamedDomainObjectProvider<BuildConfigField> = buildConfigField(name, Action {
+    it.type(typeOf<Type>())
+    configure.invoke(it)
+})
+
+@BuildConfigDsl
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Type?,

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
@@ -2,7 +2,6 @@ package org.gradle.kotlin.dsl
 
 import com.github.gmazzo.buildconfig.BuildConfigClassSpec
 import com.github.gmazzo.buildconfig.BuildConfigDsl
-import com.github.gmazzo.buildconfig.addField
 import com.github.gmazzo.buildconfig.nameOf
 import com.github.gmazzo.buildconfig.valueOf
 import org.gradle.api.provider.Provider
@@ -13,52 +12,52 @@ import kotlin.reflect.typeOf
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Type?,
-) = addField(nameOf(typeOf<Type>()), name, valueOf(value))
+) = buildConfigField(nameOf(typeOf<Type>()), name, valueOf(value))
 
 @BuildConfigDsl
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Type>,
-) = addField(nameOf(typeOf<Type>()), name, value.map(::valueOf))
+) = buildConfigField(nameOf(typeOf<Type>()), name, value.map(::valueOf))
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Array<Type>,
-) = addField(nameOf(typeOf<Array<Type>>()), name, valueOf(value))
+) = buildConfigField(nameOf(typeOf<Array<Type>>()), name, valueOf(value))
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: List<Type>,
-) = addField(nameOf(typeOf<List<Type>>()), name, valueOf(if (value is Serializable) value else ArrayList(value)))
+) = buildConfigField(nameOf(typeOf<List<Type>>()), name, valueOf(if (value is Serializable) value else ArrayList(value)))
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Set<Type>,
-) = addField(nameOf(typeOf<Set<Type>>()), name, valueOf(if (value is Serializable) value else LinkedHashSet(value)))
+) = buildConfigField(nameOf(typeOf<Set<Type>>()), name, valueOf(if (value is Serializable) value else LinkedHashSet(value)))
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldArray")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Array<Type>>,
-) = addField(nameOf(typeOf<Array<Type>>()), name, value.map(::valueOf))
+) = buildConfigField(nameOf(typeOf<Array<Type>>()), name, value.map(::valueOf))
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldList")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out List<Type>>,
-) = addField(nameOf(typeOf<List<Type>>()), name, value.map { valueOf(if (it is Serializable) it else ArrayList(it)) })
+) = buildConfigField(nameOf(typeOf<List<Type>>()), name, value.map { valueOf(if (it is Serializable) it else ArrayList(it)) })
 
 @BuildConfigDsl
 @JvmName("buildConfigFieldSet")
 inline fun <reified Type : Serializable?> BuildConfigClassSpec.buildConfigField(
     name: String,
     value: Provider<out Set<Type>>,
-) = addField(nameOf(typeOf<Set<Type>>()), name, value.map { valueOf(if (it is Serializable) it else LinkedHashSet(it)) })
+) = buildConfigField(nameOf(typeOf<Set<Type>>()), name, value.map { valueOf(if (it is Serializable) it else LinkedHashSet(it)) })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,9 @@ includeBuild("plugin")
 include(
     "demo-project:generic",
     "demo-project:groovy",
+    "demo-project:groovy-gen-kotlin",
     "demo-project:kts",
     "demo-project:kts-android",
+    "demo-project:kts-gen-java",
     "demo-project:kts-multiplatform",
 )


### PR DESCRIPTION
New DSL available:
- Added a `buildConfigField(name: String, configure: Action<BuildConfigField>)` allowing configuring the field in a closure
- Added `type`, `value`, and `expression` API to `BuildConfigField`

Other changes:
- Fixed issue with `buildConfigFields.addLater` providers
- Included cross groovy/kts demo/test projects (a `build.gradle.kts` producing `.java` output and vice-versa)