### PR TITLE
Revert "Removed reflection on Kotlin binding"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,6 @@ internal object BuildConfig {
 > buildConfigField("FILE", file("aFile").relativeToOrSelf(projectDir)) // use this instead, for instance
 > ```
 
-> [!IMPORTANT]
-> When using along with the Kotlin plugin, both needs to be loaded in the same classloader (declared in the same Gradle project, like the root one for instance)
-> ```kotlin
-> plugins {
->    id("org.jetbrains.kotlin.jvm") apply false
->    id("com.github.gmazzo.buildconfig") apply false
-> }
-> ```
-
 ## Usage in Groovy
 On your `build.gradle` add:
 ```groovy

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinHandler.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinHandler.kt
@@ -6,26 +6,31 @@ import com.github.gmazzo.buildconfig.generators.BuildConfigKotlinGenerator
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.getByName
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
+import org.gradle.api.file.SourceDirectorySet
 
 internal class KotlinHandler(
     project: Project,
     private val extension: BuildConfigExtension
-) : PluginBindingHandler<KotlinSourceSet> {
+) : PluginBindingHandler<Named> { // TODO should be KotlinSourceSet but fails on tests (but not from external project)
 
-    override val sourceSets =
-        project.extensions.getByName<KotlinSourceSetContainer>("kotlin").sourceSets
+    // project.extensions.getByName<KotlinSourceSetContainer>("kotlin").sourceSets
+    override val sourceSets = with(project.extensions.getByName("kotlin")) {
+        @Suppress("UNCHECKED_CAST")
+        javaClass.getMethod("getSourceSets")
+            .invoke(this) as NamedDomainObjectContainer<Named>
+    }
 
-    override fun nameOf(sourceSet: KotlinSourceSet): String = sourceSet.name
+    override fun nameOf(sourceSet: Named): String = sourceSet.name
 
     override fun onBind() {
         extension.generator.convention(BuildConfigKotlinGenerator())
     }
 
-    override fun onSourceSetAdded(sourceSet: KotlinSourceSet, spec: BuildConfigSourceSet) {
-        sourceSet.kotlin.srcDir(spec)
+    // sourceSet.kotlin.srcDir(spec)
+    override fun onSourceSetAdded(sourceSet: Named, spec: BuildConfigSourceSet) {
+        (sourceSet.javaClass.getMethod("getKotlin")
+            .invoke(sourceSet) as SourceDirectorySet)
+            .srcDir(spec)
     }
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinMultiplatformHandler.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinMultiplatformHandler.kt
@@ -1,13 +1,14 @@
 package com.github.gmazzo.buildconfig.internal.bindings
 
+import org.gradle.api.Named
 import org.gradle.api.tasks.SourceSet
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 internal class KotlinMultiplatformHandler(
     private val kotlinHandler: KotlinHandler
-) : PluginBindingHandler<KotlinSourceSet> by kotlinHandler {
+) : PluginBindingHandler<Named> by kotlinHandler {
 
-    override fun nameOf(sourceSet: KotlinSourceSet) = when (val name = kotlinHandler.nameOf(sourceSet)) {
+    override fun nameOf(sourceSet: Named) = when (val name = kotlinHandler.nameOf(sourceSet)) {
         KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME -> SourceSet.MAIN_SOURCE_SET_NAME
         KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME -> SourceSet.TEST_SOURCE_SET_NAME
         else -> name


### PR DESCRIPTION
This partially reverts #101 to maximize the compatibility with complex build setups.

As per the general rule classpath should be consistent and interesting plugins should be added in the same classpath, there is a special use case we want to support:

Given the following structure:
- `buildSrc/src/main/kotlin/my-constants.gradle.kts` -> uses this plugin to create some constants
- `build.gradle.kts` -> applies `my-constants` and the `koltin` plugin.

Without this reflection logic, you'll be forced to promote the `koltin` plugin as well to the `buildSrc` classpath.