### PR TITLE
Renames KMP android unit test source set to `androidUnitTest`

### DIFF
--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder.kt
@@ -23,7 +23,7 @@ internal object AndroidBinder {
     fun Project.configure(extension: BuildConfigExtension) {
         val isKMP by lazy { isKotlinMultiplatform }
         val mainSourceSetName by lazy { if (isKMP) "androidMain" else MAIN_SOURCE_SET_NAME }
-        val testSourceSetName by lazy { if (isKMP) "androidTest" else TEST_SOURCE_SET_NAME }
+        val testSourceSetName by lazy { if (isKMP) "androidUnitTest" else TEST_SOURCE_SET_NAME }
 
         afterEvaluate {
             check(isKMP == isKotlinMultiplatform) {


### PR DESCRIPTION
On KMP Android targets, Android's `test` (for unit tests) variant was mapped to `androidTest`, just because `main` was mapped to `androidMain`. 

But `androidTest` is also the default source set name for UI Tests variant on Android, and the source set were collisioning. Now the source set name for Android's Unit tests will be `androidUnitTest`.

Fixes #273.