### PR TITLE
Disable workflow jobs in forked repos

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -60,7 +60,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ !cancelled() && !github.event.repository.fork }}
+    if: ${{ !cancelled() && !github.event.repository.fork && github.ref == 'refs/heads/main' }}
     steps:
       - name: Build has passed
         if: ${{ needs.build.result != 'success' }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.repository.fork }}
+    if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Prevents failures like https://github.com/Goooler/gradle-buildconfig-plugin/actions/runs/19129325917/job/54666657557.