### PR TITLE
Overload KotlinSourceSet.buildConfig for Kotlin Dsl

### DIFF
--- a/demo-project/kts/build.gradle.kts
+++ b/demo-project/kts/build.gradle.kts
@@ -211,7 +211,12 @@ buildConfig {
 }
 
 sourceSets.test { buildConfig.buildConfigField("TEST_CONSTANT", "aTestValue") }
-kotlin.sourceSets.test { buildConfig.buildConfigField("TEST_CONSTANT2", "anotherValue") }
+kotlin.sourceSets.test {
+    buildConfig.buildConfigField("TEST_CONSTANT2", "anotherValue")
+    buildConfig {
+        buildConfigField("TEST_CONSTANT3", "anotherValue")
+    }
+}
 
 sourceSets["integrationTest"].buildConfig {
     buildConfigField("INTEGRATION_TEST_CONSTANT", "aIntTestValue")

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -180,6 +180,7 @@ public final class com/github/gmazzo/buildconfig/generators/BuildConfigKotlinGen
 }
 
 public final class org/gradle/kotlin/dsl/BuildConfigClassSpecDSLKt {
+	public static final fun buildConfig (Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;Lorg/gradle/api/Action;)V
 	public static final fun getBuildConfig (Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;)Lcom/github/gmazzo/buildconfig/BuildConfigSourceSet;
 	public static final fun invoke (Lcom/github/gmazzo/buildconfig/BuildConfigSourceSet;Lorg/gradle/api/Action;)V
 }

--- a/plugin/src/main/kotlin/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/BuildConfigClassSpecDSL.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 val KotlinSourceSet.buildConfig: BuildConfigSourceSet
     get() = (this as ExtensionAware).extensions.getByName<BuildConfigSourceSet>("buildConfig")
 
+fun KotlinSourceSet.buildConfig(action: Action<BuildConfigSourceSet>) = action.execute(buildConfig)
+
 operator fun BuildConfigSourceSet.invoke(action: Action<BuildConfigSourceSet>) =
     action.execute(this)
 


### PR DESCRIPTION
Seems `BuildConfigSourceSet.invoke` can't be accessed by the code like

```kt
kotlin.sourceSets.test {
    buildConfig {
        buildConfigField("TEST_CONSTANT3", "anotherValue")
    }
}
```

We need to add the explicit overload to make Kotlin Dsl recognize the configuration action for buildConfig.