### PR TITLE
Get rid of gradleKotlinDsl from the plugin dependencies

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     fun DependencyHandler.plugin(dependency: Provider<PluginDependency>) =
         dependency.get().run { create("$pluginId:$pluginId.gradle.plugin:$version") }
 
-    compileOnly(gradleKotlinDsl())
     compileOnly(plugin(libs.plugins.kotlin.jvm))
     compileOnly(plugin(libs.plugins.android))
 
@@ -44,7 +43,6 @@ dependencies {
     implementation(libs.kotlinpoet)
 
     testImplementation(gradleTestKit())
-    testImplementation(gradleKotlinDsl())
     testImplementation(platform(libs.junit5.bom))
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigPlugin.kt
@@ -16,9 +16,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.tasks.SourceSet
-import org.gradle.kotlin.dsl.domainObjectContainer
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
 import org.gradle.util.GradleVersion
 
 public class BuildConfigPlugin : Plugin<Project> {
@@ -32,7 +29,7 @@ public class BuildConfigPlugin : Plugin<Project> {
             "Gradle version must be at least $MIN_GRADLE_VERSION"
         }
 
-        val sourceSets = objects.domainObjectContainer(DefaultBuildConfigSourceSet::class)
+        val sourceSets = objects.domainObjectContainer(DefaultBuildConfigSourceSet::class.java)
 
         val defaultSS = sourceSets.create(SourceSet.MAIN_SOURCE_SET_NAME)
 
@@ -59,7 +56,7 @@ public class BuildConfigPlugin : Plugin<Project> {
 
             // generate at sync
             if (extension.generateAtSync.get() && isGradleSync) {
-                tasks.maybeCreate("prepareKotlinIdeaImport").dependsOn(tasks.withType<BuildConfigTask>())
+                tasks.maybeCreate("prepareKotlinIdeaImport").dependsOn(tasks.withType(BuildConfigTask::class.java))
             }
         }
 
@@ -148,12 +145,12 @@ public class BuildConfigPlugin : Plugin<Project> {
 
         configureFields(sourceSet.buildConfigFields)
 
-        sourceSet.generateTask = tasks.register<BuildConfigTask>("generate${prefix}${taskPrefix}BuildConfig") {
-            group = "BuildConfig"
-            description = "Generates the build constants class for '${sourceSet.name}' source"
+        sourceSet.generateTask = tasks.register("generate${prefix}${taskPrefix}BuildConfig", BuildConfigTask::class.java) {
+            it.group = "BuildConfig"
+            it.description = "Generates the build constants class for '${sourceSet.name}' source"
 
-            bindTo(sourceSet)
-            outputDir.set(layout.buildDirectory.dir("generated/sources/buildConfig/${sourceSet.name}"))
+            it.bindTo(sourceSet)
+            it.outputDir.set(layout.buildDirectory.dir("generated/sources/buildConfig/${sourceSet.name}"))
         }
     }
 

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTask.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigTask.kt
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.kotlin.dsl.newInstance
 import org.gradle.util.GradleVersion
 
 @CacheableTask
@@ -79,7 +78,7 @@ public abstract class BuildConfigTask : DefaultTask() {
      * It makes it compatible with Configuration Cache
      */
     private fun Project.isolate(source: BuildConfigClassSpec) =
-        objects.newInstance<BuildConfigClassSpec>(source.name).apply spec@{
+        objects.newInstance(BuildConfigClassSpec::class.java, source.name).apply spec@{
             val nullLiteral = BuildConfigValue.Literal(null)
 
             generator.value(source.generator).disallowChanges()
@@ -87,7 +86,7 @@ public abstract class BuildConfigTask : DefaultTask() {
             packageName.value(source.packageName).disallowChanges()
             documentation.value(source.documentation).disallowChanges()
             buildConfigFields.addAll(source.buildConfigFields.map { field ->
-                objects.newInstance<BuildConfigField>(field.name).apply field@{
+                objects.newInstance(BuildConfigField::class.java, field.name).apply field@{
                     this@field.type.value(field.type).disallowChanges()
                     this@field.value.value(field.value.orElse(nullLiteral)).disallowChanges()
                     this@field.position.value(field.position).disallowChanges()

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet.kt
@@ -6,7 +6,6 @@ import javax.inject.Inject
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.newInstance
 
 internal abstract class DefaultBuildConfigSourceSet(
     classSpec: BuildConfigClassSpec,
@@ -23,9 +22,9 @@ internal abstract class DefaultBuildConfigSourceSet(
         name: String,
         objects: ObjectFactory,
     ) : this(
-        classSpec = objects.newInstance<DefaultBuildConfigClassSpec>(name),
+        classSpec = objects.newInstance(DefaultBuildConfigClassSpec::class.java, name),
         extraSpecs = objects.domainObjectContainer(DefaultBuildConfigClassSpec::class.java) { extraName ->
-            objects.newInstance<DefaultBuildConfigClassSpec>(extraName)
+            objects.newInstance(DefaultBuildConfigClassSpec::class.java, extraName)
         }
     )
 

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder.kt
@@ -14,7 +14,6 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.kotlin.dsl.closureOf
 
 internal object AndroidBinder {
 
@@ -188,5 +187,21 @@ internal object AndroidBinder {
             "AndroidTest" -> return "androidInstrumentedTest$suffix"
             else -> "android$suffix"
         }
+    }
+
+    private fun <T> Any.closureOf(action: T.() -> Unit): Closure<Any?> =
+        KotlinClosure1(action, this, this)
+
+    /**
+     * https://github.com/gradle/gradle/blob/cc8a80a2497e4bc05a2b2c6cc264a990de88beb4/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt#L76-L95
+     */
+    private class KotlinClosure1<in T : Any?, V : Any>(
+        val function: T.() -> V?,
+        owner: Any? = null,
+        thisObject: Any? = null
+    ) : Closure<V?>(owner, thisObject) {
+
+        @Suppress("unused") // to be called dynamically by Groovy
+        fun doCall(it: T): V? = it.function()
     }
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/JavaBinder.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/JavaBinder.kt
@@ -5,14 +5,11 @@ import com.github.gmazzo.buildconfig.BuildConfigSourceSet
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.kotlin.dsl.add
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.provideDelegate
 
 internal object JavaBinder {
 
     fun Project.configure(extension: BuildConfigExtension) {
-        val sourceSets: SourceSetContainer by extensions
+        val sourceSets = extensions.getByType(SourceSetContainer::class.java)
 
         sourceSets.configureEach { sourceSet ->
             val spec = extension.sourceSets.maybeCreate(sourceSet.name)
@@ -23,6 +20,6 @@ internal object JavaBinder {
     }
 
     internal fun ExtensionAware.registerExtension(sourceSet: BuildConfigSourceSet) =
-        extensions.add(BuildConfigSourceSet::class, "buildConfig", sourceSet)
+        extensions.add(BuildConfigSourceSet::class.java, "buildConfig", sourceSet)
 
 }

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinBinder.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/bindings/KotlinBinder.kt
@@ -14,7 +14,6 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
-import org.gradle.kotlin.dsl.getByName
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_MAIN_SOURCE_SET_NAME
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_TEST_SOURCE_SET_NAME
 
@@ -40,7 +39,7 @@ internal object KotlinBinder {
     }
 
     private val Project.kotlin: ExtensionAware /*KotlinProjectExtension*/
-        get() = extensions.getByName<ExtensionAware>("kotlin")
+        get() = extensions.getByName("kotlin") as ExtensionAware
 
     @Suppress("UNCHECKED_CAST")
     private val ExtensionAware/*KotlinProjectExtension*/.sourceSets

--- a/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
+++ b/plugin/src/main/kotlin/org/gradle/kotlin/dsl/BuildConfigClassSpecDSL.kt
@@ -14,7 +14,7 @@ import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 public val KotlinSourceSet.buildConfig: BuildConfigSourceSet
-    get() = (this as ExtensionAware).extensions.getByName<BuildConfigSourceSet>("buildConfig")
+    get() = (this as ExtensionAware).extensions.getByType(BuildConfigSourceSet::class.java)
 
 public fun KotlinSourceSet.buildConfig(action: Action<BuildConfigSourceSet>): Unit = action.execute(buildConfig)
 

--- a/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTaskTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTaskTest.kt
@@ -5,8 +5,6 @@ import com.github.gmazzo.buildconfig.generators.BuildConfigGeneratorSpec
 import com.github.gmazzo.buildconfig.internal.DefaultBuildConfigClassSpec
 import io.mockk.mockk
 import io.mockk.verify
-import org.gradle.kotlin.dsl.newInstance
-import org.gradle.kotlin.dsl.register
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 
@@ -16,7 +14,7 @@ class BuildConfigTaskTest {
 
     private val generator: BuildConfigGenerator = mockk(relaxUnitFun = true)
 
-    private val spec: BuildConfigClassSpec = project.objects.newInstance<DefaultBuildConfigClassSpec>("spec").apply {
+    private val spec: BuildConfigClassSpec = project.objects.newInstance(DefaultBuildConfigClassSpec::class.java, "spec").apply {
         generator.set(this@BuildConfigTaskTest.generator)
         className.set("aClassName")
         packageName.set("aPackage")
@@ -25,9 +23,9 @@ class BuildConfigTaskTest {
 
     private val outDir = project.layout.buildDirectory.dir("outDir")
 
-    private val task = project.tasks.register<BuildConfigTask>("testedTask") {
-        outputDir.set(outDir)
-        specs.add(spec)
+    private val task = project.tasks.register("testedTask", BuildConfigTask::class.java) {
+        it.outputDir.set(outDir)
+        it.specs.add(spec)
     }
 
     @Test


### PR DESCRIPTION
It should not rely on Kotlin Dsl dependencies in plugin development, but I don't remember the sources I saw.

```diff
OLD: old.jar
NEW: new.jar

 JAR   │ old       │ new       │ diff     
───────┼───────────┼───────────┼──────────
 class │ 341.9 KiB │ 334.1 KiB │ -7.8 KiB 
 other │     236 B │     236 B │      0 B 
───────┼───────────┼───────────┼──────────
 total │ 342.1 KiB │ 334.3 KiB │ -7.8 KiB 

 CLASSES │ old │ new │ diff         
─────────┼─────┼─────┼──────────────
 classes │  62 │  62 │  0 (+1 -1)   
 methods │ 870 │ 869 │ -1 (+11 -12) 
  fields │ 144 │ 143 │ -1 (+1 -2)   

=================
====   JAR   ====
=================

 size      │ diff     │ path                                                                                          
───────────┼──────────┼───────────────────────────────────────────────────────────────────────────────────────────────
   2.4 KiB │ +2.4 KiB │ + com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder$KotlinClosure1.class          
           │ -1.1 KiB │ - com/github/gmazzo/buildconfig/BuildConfigPlugin$inlined$sam$i$org_gradle_api_Action$0.class 
    23 KiB │ -1.3 KiB │ ∆ com/github/gmazzo/buildconfig/BuildConfigPlugin.class                                       
  13.2 KiB │   -619 B │ ∆ com/github/gmazzo/buildconfig/BuildConfigTask.class                                         
   3.8 KiB │     +5 B │ ∆ com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet$iterator$1.class         
  15.4 KiB │ -1.2 KiB │ ∆ com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet.class                    
    23 KiB │   +557 B │ ∆ com/github/gmazzo/buildconfig/internal/bindings/AndroidBinder.class                         
   4.1 KiB │ -3.4 KiB │ ∆ com/github/gmazzo/buildconfig/internal/bindings/JavaBinder.class                            
  10.6 KiB │ -1.1 KiB │ ∆ com/github/gmazzo/buildconfig/internal/bindings/KotlinBinder.class                          
  12.4 KiB │ -1.9 KiB │ ∆ org/gradle/kotlin/dsl/BuildConfigClassSpecDSLKt.class                                       
───────────┼──────────┼───────────────────────────────────────────────────────────────────────────────────────────────
 107.8 KiB │ -7.8 KiB │ (total)                                                                                       


=====================
====   CLASSES   ====
=====================

CLASSES:

   old │ new │ diff      
  ─────┼─────┼───────────
   62  │ 62  │ 0 (+1 -1) 
  
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1
  
  - com.github.gmazzo.buildconfig.BuildConfigPlugin$inlined$sam$i$org_gradle_api_Action$0
  

METHODS:

   old │ new │ diff         
  ─────┼─────┼──────────────
   870 │ 869 │ -1 (+11 -12) 
  
  + com.github.gmazzo.buildconfig.BuildConfigPlugin configureSourceSet$lambda$7(Function1, Object)
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder closureOf(Object, Function1) → Closure
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1 <init>(Function1, Object, Object)
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1 <init>(Function1, Object, Object, int, DefaultConstructorMarker)
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1 doCall(Object) → Object
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1 getFunction() → Function1
  + com.github.gmazzo.buildconfig.internal.bindings.JavaBinder configure$lambda$0(BuildConfigExtension, SourceSet) → Unit
  + com.github.gmazzo.buildconfig.internal.bindings.JavaBinder configure$lambda$1(Function1, Object)
  + groovy.lang.Closure <init>(Object, Object)
  + org.gradle.api.plugins.ExtensionContainer getByType(Class) → Object
  + org.gradle.api.tasks.TaskContainer withType(Class) → TaskCollection
  
  - com.github.gmazzo.buildconfig.BuildConfigPlugin$inlined$sam$i$org_gradle_api_Action$0 <init>(Function1)
  - com.github.gmazzo.buildconfig.BuildConfigPlugin$inlined$sam$i$org_gradle_api_Action$0 execute(Object)
  - com.github.gmazzo.buildconfig.internal.bindings.JavaBinder configure$lambda$0(ExtensionContainer) → SourceSetContainer
  - com.github.gmazzo.buildconfig.internal.bindings.JavaBinder configure$lambda$1(BuildConfigExtension, SourceSet) → Unit
  - com.github.gmazzo.buildconfig.internal.bindings.JavaBinder configure$lambda$2(Function1, Object)
  - java.lang.StringBuilder append(Object) → StringBuilder
  - kotlin.jvm.internal.PropertyReference0Impl <init>(Class, String, String, int)
  - kotlin.jvm.internal.Reflection property0(PropertyReference0) → KProperty0
  - kotlin.reflect.KProperty getName() → String
  - org.gradle.api.tasks.TaskCollection withType(Class) → TaskCollection
  - org.gradle.kotlin.dsl.GroovyInteroperabilityKt closureOf(Object, Function1) → Closure
  - org.gradle.kotlin.dsl.NamedDomainObjectCollectionExtensionsKt provideDelegate(Object, Object, KProperty) → Object
  

FIELDS:

   old │ new │ diff       
  ─────┼─────┼────────────
   144 │ 143 │ -1 (+1 -2) 
  
  + com.github.gmazzo.buildconfig.internal.bindings.AndroidBinder$KotlinClosure1 function: Function1
  
  - com.github.gmazzo.buildconfig.BuildConfigPlugin$inlined$sam$i$org_gradle_api_Action$0 function: Function1
  - com.github.gmazzo.buildconfig.internal.bindings.JavaBinder $$delegatedProperties: KProperty[]
```