### PR TITLE
Indicate the Maven Central badge to the plugin jar dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub](https://img.shields.io/github/license/gmazzo/gradle-buildconfig-plugin)
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.gmazzo.buildconfig/com.github.gmazzo.buildconfig.gradle.plugin)](https://central.sonatype.com/artifact/com.github.gmazzo.buildconfig/com.github.gmazzo.buildconfig.gradle.plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.gmazzo.buildconfig/plugin)](https://central.sonatype.com/artifact/com.github.gmazzo.buildconfig/plugin)
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/com.github.gmazzo.buildconfig)](https://plugins.gradle.org/plugin/com.github.gmazzo.buildconfig)
 [![Build Status](https://github.com/gmazzo/gradle-buildconfig-plugin/actions/workflows/ci-cd.yaml/badge.svg)](https://github.com/gmazzo/gradle-buildconfig-plugin/actions/workflows/ci-cd.yaml)
 [![codecov](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/gmazzo/gradle-buildconfig-plugin)


### PR DESCRIPTION
The artifact `plugin` contains the plugin jars, but `com.github.gmazzo.buildconfig.gradle.plugin` contains the plugin marker.