### PR TITLE
Renamed tasks names to `generateBuildConfigClasses`

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ def generateResourcesConstants = tasks.register("generateResourcesConstants") {
     }
 }
 
-tasks.generateBuildConfig {
+tasks.generateBuildConfigClasses {
     dependsOn(generateResourcesConstants)
 }
 ```

--- a/demo-project/generic/build.gradle.kts
+++ b/demo-project/generic/build.gradle.kts
@@ -35,7 +35,7 @@ buildConfig {
 // everything below here are just helper code to allow testing the plugin as we can't rely on any framework like JUnit
 
 val generateBuildConfigTest by tasks.registering(AssertGeneratedFile::class) {
-    generatedDir.set(tasks.generateBuildConfig.flatMap { it.outputDir })
+    generatedDir.set(tasks.generateBuildConfigClasses.flatMap { it.outputDir })
     filePath.set("com/github/gmazzo/buildconfig/demos/generic/BuildConfig.java")
     expectedContent.set(
         """
@@ -62,7 +62,7 @@ val generateBuildConfigTest by tasks.registering(AssertGeneratedFile::class) {
 }
 
 val generateBuildResourcesBuildConfigTest by tasks.registering(AssertGeneratedFile::class) {
-    generatedDir.set(tasks.generateBuildConfig.flatMap { it.outputDir })
+    generatedDir.set(tasks.generateBuildConfigClasses.flatMap { it.outputDir })
     filePath.set("com/github/gmazzo/buildconfig/demos/generic/BuildResources.java")
     expectedContent.set(
         """

--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigPlugin.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/BuildConfigPlugin.kt
@@ -95,7 +95,6 @@ public class BuildConfigPlugin : Plugin<Project> {
             defaultSS -> ""
             else -> sourceSet.name.replace("[_-]".toRegex(), "").capitalized
         }
-        val taskPrefix = if (plugins.hasPlugin("com.android.base")) "NonAndroid" else ""
 
         sourceSet.className
             .convention("${prefix}BuildConfig")
@@ -145,7 +144,7 @@ public class BuildConfigPlugin : Plugin<Project> {
 
         configureFields(sourceSet.buildConfigFields)
 
-        sourceSet.generateTask = tasks.register<BuildConfigTask>("generate${prefix}${taskPrefix}BuildConfig") {
+        sourceSet.generateTask = tasks.register<BuildConfigTask>("generate${prefix}BuildConfigClasses") {
             group = "BuildConfig"
             description = "Generates the build constants class for '${sourceSet.name}' source"
 

--- a/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTaskCacheabilityTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigTaskCacheabilityTest.kt
@@ -74,10 +74,10 @@ class BuildConfigTaskCacheabilityTest {
         buildScript.appendText("buildConfig.useJavaOutput()\n")
 
         val firstRun = runner.build()
-        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfig")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfigClasses")?.outcome)
 
         val secondRun = runner.build()
-        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfig")?.outcome)
+        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfigClasses")?.outcome)
     }
 
     @Test
@@ -85,15 +85,15 @@ class BuildConfigTaskCacheabilityTest {
         buildScript.appendText("buildConfig.useKotlinOutput()\n")
 
         val firstRun = runner.build()
-        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfig")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, firstRun.task(":generateBuildConfigClasses")?.outcome)
 
         val secondRun = runner.build()
-        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfig")?.outcome)
+        assertEquals(TaskOutcome.FROM_CACHE, secondRun.task(":generateBuildConfigClasses")?.outcome)
 
         buildScript.appendText("buildConfig.useKotlinOutput { topLevelConstants = true }\n")
 
         val thirdRun = runner.build()
-        assertEquals(TaskOutcome.SUCCESS, thirdRun.task(":generateBuildConfig")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, thirdRun.task(":generateBuildConfigClasses")?.outcome)
     }
 
 }


### PR DESCRIPTION
To provide a consistent task naming behavior that avoid conflicts with Android's plugin, the main `generateBuildConfig` was be renamed to `generateBuildConfigClasses`. The same pattern applied to other source sets, i.e. `generateTestBuildConfig` to `generateTestBuildConfigClasses`