### PR TITLE
Fixed `supersededBy` call

### DIFF
--- a/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet.kt
+++ b/plugin/src/main/kotlin/com/github/gmazzo/buildconfig/internal/DefaultBuildConfigSourceSet.kt
@@ -65,8 +65,8 @@ internal abstract class DefaultBuildConfigSourceSet(
 
         if (!isSuperseded) {
             isSuperseded = true
-            generateTask.configure {
-                supersededBy(other)
+            generateTask.configure { t ->
+                t.supersededBy(other)
             }
         }
 

--- a/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigSupersededByTest.kt
+++ b/plugin/src/test/kotlin/com/github/gmazzo/buildconfig/BuildConfigSupersededByTest.kt
@@ -1,0 +1,33 @@
+package com.github.gmazzo.buildconfig
+
+import com.github.gmazzo.buildconfig.internal.BuildConfigSourceSetInternal
+import com.github.gmazzo.buildconfig.internal.DefaultBuildConfigSourceSet
+import com.github.gmazzo.buildconfig.internal.capitalized
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class BuildConfigSupersededByTest {
+    private val project = ProjectBuilder.builder().build()
+
+    private fun createSourceSet(name: String): BuildConfigSourceSetInternal = with(project) {
+        objects.newInstance<DefaultBuildConfigSourceSet>(name).apply {
+            generateTask = tasks.register<BuildConfigTask>("generate${name.capitalized}BuildConfigClasses") {
+                outputDir.set(layout.buildDirectory.dir("generated/sources/buildConfig/$name"))
+            }
+        }
+    }
+
+    @Test
+    fun `supersededBy with forClass should not fail when task is realized`() {
+        val parent = createSourceSet("test")
+        val child = createSourceSet("testDebug")
+
+        parent.forClass("MyBuildConfig")
+        parent.supersededBy(child)
+
+        assertDoesNotThrow { parent.generateTask.get() }
+    }
+}


### PR DESCRIPTION
I got a build regression failure from the bump to v6.0.8, [see here if you're interested in the details](https://github.com/jonapoul/aktual/pull/893). Key part:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':aktual-app:android:generateDebugLintReportModel'.
> Could not create task ':aktual-app:android:generateTestBuildConfigClasses'.
   > Cannot add a DefaultBuildConfigClassSpec with name 'Resources' as a DefaultBuildConfigClassSpec with that name already exists.
```

Apparently triggered when [configuring with a `forClass` call within the `test` buildconfig source set](https://github.com/jonapoul/aktual/blob/main/gradle/build-logic/src/main/kotlin/aktual/gradle/ConventionTest.kt#L34-L45) like this:

```kotlin
extensions.configure(BuildConfigExtension::class) {
  sourceSets.named("test") {
    forClass("Resources") {
      // config
    }
  }
}
```

Added a fix plus a regression test - turns out the call to `supersededBy` was calling itself before which was apparently causing some recursive(?) behaviour between related source sets.